### PR TITLE
Inadvertent whitespace being output to client when including analytics.php

### DIFF
--- a/lib/analytics.php
+++ b/lib/analytics.php
@@ -60,5 +60,4 @@ class Analytics {
                           "before track or identify");
     }
   }
-};
-?>
+}

--- a/lib/analytics/client.php
+++ b/lib/analytics/client.php
@@ -109,4 +109,3 @@ class Analytics_Client {
     return array( "library" => "analytics-php" );
   }
 }
-?>

--- a/lib/analytics/consumers/file.php
+++ b/lib/analytics/consumers/file.php
@@ -92,5 +92,3 @@ class Analytics_FileConsumer extends Analytics_Consumer {
     return fwrite($this->file_handle, $content) == strlen($content);
   }
 }
-?>
-

--- a/lib/analytics/consumers/fork_curl.php
+++ b/lib/analytics/consumers/fork_curl.php
@@ -103,4 +103,3 @@ class Analytics_ForkCurlConsumer extends Analytics_QueueConsumer {
     return $exit == 0;
   }
 }
-?>

--- a/lib/analytics/consumers/queue_consumer.php
+++ b/lib/analytics/consumers/queue_consumer.php
@@ -76,4 +76,3 @@ abstract class Analytics_QueueConsumer extends Analytics_Consumer {
    */
   abstract function flushBatch($batch);
 }
-?>

--- a/lib/analytics/consumers/socket.php
+++ b/lib/analytics/consumers/socket.php
@@ -209,5 +209,3 @@ class Analytics_SocketConsumer extends Analytics_QueueConsumer {
     );
   }
 }
-?>
-


### PR DESCRIPTION
All the included API files have a closing `?>` tag and some of them have whitespace afterwards.  This creates unexpected output for the client, which breaks parsing things like JSON, and can cause errors with starting sessions, etc.

I removed the closing tags, and the extra whitespace.
