### PR TITLE
Undefined variable $written causes fatal error.

### DIFF
--- a/lib/Analytics/Consumer/Socket.php
+++ b/lib/Analytics/Consumer/Socket.php
@@ -93,7 +93,7 @@ class Analytics_Consumer_Socket extends Analytics_QueueConsumer {
         $this->handleError($e->getCode(), $e->getMessage());
         $closed = true;
       }
-      if (!isset($written)) {
+      if (!isset($written) || !$written) {
         $closed = true;
       } else {
         $bytes_written += $written;


### PR DESCRIPTION
When an exception is immediately caught on the first fwrite, $written has not been defined yet and the fatal error occurs.
