### PR TITLE
use same directory for temp files as for log file

### DIFF
--- a/file_reader.py
+++ b/file_reader.py
@@ -119,10 +119,15 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     default_file = os.path.join(tempfile.gettempdir(), 'analytics.log')
-    processing_filename = os.path.join(tempfile.gettempdir(),
-                                'analytics-%d.log' % random.randint(0, 1000))
 
     filename = args.file or default_file
+
+    # Use the same directory for processing the log as where it is stored.
+    # This prevents "Invalid cross-device link" errors.
+    processing_dir = os.path.dirname(filename)
+
+    processing_filename = os.path.join(processing_dir,
+                                'analytics-%d.log' % random.randint(0, 1000))
 
     if not os.path.exists(filename):
         print 'Error: The filename you specified doesn\'t exist: ', filename


### PR DESCRIPTION
We keep `/tmp` on a separate file system. We wanted to move the segmentio log to `/var/tmp` because `/tmp` gets blown away on reboot.

So then `file_reader.py` starts throwing this error

``` python
Traceback (most recent call last):
 File "/var/www/www.boat-ed.com/lib/Analytics/file_reader.py", line 133, in <module>
   os.rename(filename, processing_filename)
OSError: [Errno 18] Invalid cross-device link
```

Basically, can't mv files from `/var/tmp` to `/tmp` because they are different filesystems.
