### PR TITLE
fixing validation for Segment::page() calls

### DIFF
--- a/lib/Segment.php
+++ b/lib/Segment.php
@@ -70,8 +70,6 @@ class Segment {
    */
   public static function page(array $message) {
     self::checkClient();
-    $name = !empty($message["name"]);
-    self::assert($name, "Segment::page() requires userId or anonymousId");
     self::validate($message, "page");
     return self::$client->page($message);
   }
@@ -84,7 +82,6 @@ class Segment {
    */
   public static function screen(array $message) {
     self::checkClient();
-    $name = !empty($message["name"]);
     self::validate($message, "screen");
     return self::$client->screen($message);
   }

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -28,13 +28,19 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
 
   function testPage(){
     $this->assertTrue(Segment::page(array(
-      "anonymousId" => "user-id",
+      "anonymousId" => "anonymous-id",
       "name" => "analytics-php",
       "category" => "docs",
       "properties" => array(
         "path" => "/docs/libraries/php/",
         "url" => "https://segment.io/docs/libraries/php/"
       )
+    )));
+  }
+
+  function testBasicPage(){
+    $this->assertTrue(Segment::page(array(
+      "anonymousId" => "anonymous-id"
     )));
   }
 
@@ -46,6 +52,12 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
       "properties" => array(
         "points" => 300
       )
+    )));
+  }
+
+  function testBasicScreen(){
+    $this->assertTrue(Segment::screen(array(
+      "anonymousId" => "anonymous-id"
     )));
   }
 


### PR DESCRIPTION
Previously page() calls would fail if the `name` was not included,
this updates the validation to since `name` is an optional field.

@yields 
