### PR TITLE
suppressing logs generated by socket resets

### DIFF
--- a/lib/Segment/Consumer/Socket.php
+++ b/lib/Segment/Consumer/Socket.php
@@ -52,7 +52,7 @@ class Segment_Consumer_Socket extends Segment_QueueConsumer {
 
     try {
       # Open our socket to the API Server.
-      $socket = pfsockopen($protocol . "://" . $host, $port, $errno,
+      $socket = @pfsockopen($protocol . "://" . $host, $port, $errno,
                            $errstr, $timeout);
 
       # If we couldn't open the socket, handle the error.


### PR DESCRIPTION
Quite a few people mentioned that they were seeing connection
resets as part of normal operation. This commit should prevent
those messages from being logged since the library should
retry anyway.

[Suggested in #12](https://github.com/segmentio/analytics-php/issues/12#issuecomment-56226531)

cc @yields 
