### PR TITLE
suppressing logs generated when attempting to write to a reset socket

### DIFF
--- a/lib/Segment/Consumer/Socket.php
+++ b/lib/Segment/Consumer/Socket.php
@@ -87,7 +87,7 @@ class Segment_Consumer_Socket extends Segment_QueueConsumer {
     # Write the request
     while (!$closed && $bytes_written < $bytes_total) {
       try {
-        $written = fwrite($socket, substr($req, $bytes_written));
+        $written = @fwrite($socket, substr($req, $bytes_written));
       } catch (Exception $e) {
         $this->handleError($e->getCode(), $e->getMessage());
         $closed = true;


### PR DESCRIPTION
Suppressing log entries we don't want to see. Carrying SegmentIO's changes to the cause of my problem.
