### PR TITLE
fix: identify(), group() with empty traits

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -64,6 +64,7 @@ class Segment_Client {
    */
   public function identify(array $message) {
     $message = $this->message($message);
+    if (!isset($message["traits"])) $message["traits"] = new stdClass;
     $message["type"] = "identify";
     return $this->consumer->identify($message);
   }
@@ -76,6 +77,7 @@ class Segment_Client {
    */
   public function group(array $message) {
     $message = $this->message($message);
+    if (!isset($message["traits"])) $message["traits"] = new stdClass;
     $message["type"] = "group";
     return $this->consumer->group($message);
   }

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -6,7 +6,7 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
 
   function setUp() {
     date_default_timezone_set("UTC");
-    Segment::init("oq0vdlg7yi");
+    Segment::init("oq0vdlg7yi", array("debug" => true));
   }
 
   function testTrack() {
@@ -68,6 +68,30 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
         "loves_php" => false,
         "birthday" => time()
       )
+    )));
+  }
+
+  function testEmptyTraits() {
+    $this->assertTrue(Segment::identify(array(
+      "userId" => "empty-traits"
+    )));
+
+    $this->assertTrue(Segment::group(array(
+      "userId" => "empty-traits",
+      "groupId" => "empty-traits"
+    )));
+  }
+
+  function testEmptyProperties() {
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "empty-properties"
+    )));
+
+    $this->assertTrue(Segment::page(array(
+      "category" => "empty-properties",
+      "name" => "empty-properties",
+      "userId" => "user-id"
     )));
   }
 

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -95,7 +95,7 @@ class ConsumerFileTest extends PHPUnit_Framework_TestCase {
 
   function testProductionProblems() {
     # Open to a place where we should not have write access.
-    $client = new Segment_Client("testsecret",
+    $client = new Segment_Client("oq0vdlg7yi",
                           array("consumer" => "file",
                                 "filename" => "/dev/xxxxxxx" ));
 


### PR DESCRIPTION
this fix will default an empty object as .traits

cc @calvinfo 
