### PR TITLE
support microtime

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -125,14 +125,26 @@ class Segment_Client {
   }
 
   /**
-   * Formats a timestamp by making sure it is set, and then converting it to
-   * iso8601 format.
+   * Formats a timestamp by making sure it is set
+   * and converting it to iso8601.
+   *
+   * The timestamp can be time in seconds `time()` or `microseconds(true)`.
+   * any other input is considered an error and the method will return a new date.
+   *
+   * Note: php's date() "u" format (for microseconds) has a bug in it
+   * it always shows `.000` for microseconds since `date()` only accepts
+   * ints, so we have to construct the date ourselves if microtime is passed.
+   * 
    * @param  time $timestamp - time in seconds (time())
    */
-  private function formatTime($timestamp) {
-    if ($timestamp == null) $timestamp = time();
-    # Format for iso8601
-    return date("c", $timestamp);
+  private function formatTime($ts) {
+    if ($ts == null) $ts = time();
+    if ("integer" == gettype($ts)) return date("c", $ts);
+    if (-1 == ($pos = strrpos($ts, "."))) return date("c");
+    $sec = substr($ts, 0, $pos);
+    $usec = substr($ts, $pos);
+    $fmt = sprintf("Y-m-d\TH:i:s%sP", $usec);
+    return date($fmt, (int)$sec);
   }
 
   /**

--- a/send.php
+++ b/send.php
@@ -69,7 +69,9 @@ $successful = 0;
 foreach ($lines as $line) {
   if (!trim($line)) continue;
   $payload = json_decode($line, true);
-  $payload["timestamp"] = strtotime($payload["timestamp"]);
+  $dt = new DateTime($payload["timestamp"]);
+  $ts = floatval($dt->getTimestamp() . "." . $dt->format("u"));
+  $payload["timestamp"] = $ts;
   $type = $payload["type"];
   $ret = call_user_func_array(array("Segment", $type), array($payload));
   if ($ret) $successful++;

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -26,6 +26,19 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
     )));
   }
 
+  function testMicrotime(){
+    $this->assertTrue(Segment::page(array(
+      "anonymousId" => "anonymous-id",
+      "name" => "analytics-php-microtime",
+      "category" => "docs",
+      "timestamp" => microtime(true),
+      "properties" => array(
+        "path" => "/docs/libraries/php/",
+        "url" => "https://segment.io/docs/libraries/php/"
+      )
+    )));    
+  }
+
   function testPage(){
     $this->assertTrue(Segment::page(array(
       "anonymousId" => "anonymous-id",

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -26,7 +26,8 @@ class ConsumerFileTest extends PHPUnit_Framework_TestCase {
   function testTrack() {
     $this->assertTrue($this->client->track(array(
       "userId" => "some-user",
-      "event" => "File PHP Event"
+      "event" => "File PHP Event - Microtime",
+      "timestamp" => microtime(true),
     )));
     $this->checkWritten("track");
   }


### PR DESCRIPTION
adds support for `microtime(true)` to the client and the file consumer (`send.php`) with backwards compatibility so `time()` and `microtime(true)` would work fine.
PHP `date()` is kinda awkward, no support for microtime (or at least it's buggy), i included some comments above `formatTime()`, didn't find a nicer builtin way to do this.

lmk what you think!

cc @calvinfo 