### PR TITLE
Add updated PHP version requirement for @phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     }
   ],
   "require": {
-    "php": ">=5.3"
+    "php": ">=5.3.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "3.7.*"
+    "phpunit/phpunit": "~4.0"
   },
   "autoload": {
     "files": ["lib/Segment.php"]


### PR DESCRIPTION
Updated PHP version to `5.3.3` since this is the least required version in @phpunit. Also updated PHPUnit version to `~4.0`.

Read more at https://github.com/sebastianbergmann/phpunit/blob/master/composer.json