### PR TITLE
formatTime: use is_*

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -140,13 +140,18 @@ class Segment_Client {
   private function formatTime($ts) {
     // time()
     if ($ts == null) $ts = time();
-    if ("integer" == gettype($ts)) return date("c", $ts);
+    if (is_integer($ts)) return date("c", $ts);
 
     // anything else return a new date.
-    if ("double" != gettype($ts)) return date("c");
+    if (!is_float($ts)) return date("c");
+
+    // fix for floatval casting in send.php
+    $parts = explode(".", (string)$ts);
+    if (!isset($parts[1])) return date("c", (int)$parts[0]);
 
     // microtime(true)
-    list($sec, $usec) = explode(".", (string)$ts);
+    $sec = (int)$parts[0];
+    $usec = (int)$parts[1];
     $fmt = sprintf("Y-m-d\TH:i:s%sP", $usec);
     return date($fmt, (int)$sec);  
   }

--- a/send.php
+++ b/send.php
@@ -70,7 +70,7 @@ foreach ($lines as $line) {
   if (!trim($line)) continue;
   $payload = json_decode($line, true);
   $dt = new DateTime($payload["timestamp"]);
-  $ts = doubleval($dt->getTimestamp() . "." . $dt->format("u"));
+  $ts = floatval($dt->getTimestamp() . "." . $dt->format("u"));
   $payload["timestamp"] = $ts;
   $type = $payload["type"];
   $ret = call_user_func_array(array("Segment", $type), array($payload));


### PR DESCRIPTION
closes #49 and #48 

the issue was that we cast to `floatval()` in `send.php` but then only support `integer`s in `formatTime()` this fixes the issue so that we support `floats` (coming from `microtime(true)` or `send.php`) and `ints` (from `time()`).

another issue i found and [fixed](https://github.com/segmentio/analytics-php/blob/master/send.php#L57) in 1.1.2 is that `send.php` used to listen on `on_error` instead of `error_handler`, added a test to ensure `send.php` catches errors too.

cc @calvinfo 