### PR TITLE
Fix batch size check before flushing tracking queue

### DIFF
--- a/lib/Segment/QueueConsumer.php
+++ b/lib/Segment/QueueConsumer.php
@@ -103,7 +103,7 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
 
     $count = array_push($this->queue, $item);
 
-    if ($count > $this->batch_size)
+    if ($count >= $this->batch_size)
       $this->flush();
 
     return true;


### PR DESCRIPTION
This fixes the ability to send a batch with a single tracking event. 