### PR TITLE
socket open error checking fix

### DIFF
--- a/lib/Segment/Consumer/Socket.php
+++ b/lib/Segment/Consumer/Socket.php
@@ -56,7 +56,7 @@ class Segment_Consumer_Socket extends Segment_QueueConsumer {
                            $errstr, $timeout);
 
       # If we couldn't open the socket, handle the error.
-      if ($errno != 0) {
+      if (false === $socket) {
         $this->handleError($errno, $errstr);
         $this->socket_failed = true;
         return false;

--- a/test/ConsumerSocketTest.php
+++ b/test/ConsumerSocketTest.php
@@ -134,5 +134,21 @@ class ConsumerSocketTest extends PHPUnit_Framework_TestCase {
 
     $client->__destruct();
   }
+
+  /**
+   * @expectedException \RuntimeException
+   */
+  function testConnectionError() {
+    $client = new Segment_Client("x", array(
+      "consumer"      => "socket",
+      "host"          => "api.segment.ioooooo",
+      "error_handler" => function ($errno, $errmsg) {
+        throw new \RuntimeException($errmsg, $errno);
+      },
+    ));
+
+    $client->track(array("user_id" => "some-user", "event" => "Event"));
+    $client->__destruct();
+  }
 }
 ?>


### PR DESCRIPTION
According to http://php.net/manual/en/function.fsockopen.php the `$errno` can equal to 0 in that case also, when the error occurred before the `connect()` call. The correct checking of the success of creating the socket is checking the function's return value. This can cause silent errors now.
This PR contains the fix along with a test for it.