### PR TITLE
Allow string timestamps and more timestamp values

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -139,11 +139,17 @@ class Segment_Client {
    */
   private function formatTime($ts) {
     // time()
-    if ($ts == null) $ts = time();
-    if (is_integer($ts)) return date("c", $ts);
+    if ($ts == null || !$ts) $ts = time();
+    if (filter_var($ts, FILTER_VALIDATE_INT) !== false) return date("c", (int) $ts);
 
-    // anything else return a new date.
-    if (!is_float($ts)) return date("c");
+    // anything else try to strtotime the date.
+    if (filter_var($ts, FILTER_VALIDATE_FLOAT) === false) {
+      if (is_string($ts)) {
+        return date("c", strtotime($ts));
+      } else {
+        return date("c");
+      }
+    }
 
     // fix for floatval casting in send.php
     $parts = explode(".", (string)$ts);

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -183,7 +183,7 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(Segment::track(array(
       "userId" => "user-id",
       "event" => "invalid-float-timestamp",
-      "timestamp" => ((string) mktime(0, 0, 0, date('n'), 1, date('Y'))) + '.';
+      "timestamp" => ((string) mktime(0, 0, 0, date('n'), 1, date('Y'))) . '.'
     )));
   }
 }

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -142,5 +142,49 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
       "userId" => "user-id"
     )));
   }
+
+  function testTimestamps() {
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "integer-timestamp",
+      "timestamp" => (int) mktime(0, 0, 0, date('n'), 1, date('Y'))
+    )));
+
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "string-integer-timestamp",
+      "timestamp" => (string) mktime(0, 0, 0, date('n'), 1, date('Y'))
+    )));
+
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "iso8630-timestamp",
+      "timestamp" => date(DATE_ATOM, mktime(0, 0, 0, date('n'), 1, date('Y')))
+    )));
+
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "iso8601-timestamp",
+      "timestamp" => date(DATE_ATOM, mktime(0, 0, 0, date('n'), 1, date('Y')))
+    )));
+
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "strtotime-timestamp",
+      "timestamp" => strtotime('1 week ago')
+    )));
+
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "microtime-timestamp",
+      "timestamp" => microtime(true)
+    )));
+
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "invalid-float-timestamp",
+      "timestamp" => ((string) mktime(0, 0, 0, date('n'), 1, date('Y'))) + '.';
+    )));
+  }
 }
 ?>


### PR DESCRIPTION
- i think this fixes #52 , not sure
- use case was giving a string timestamp or any timestamp that wasnt casted as an (int) to the 'timestamp' parameter would make it ignore it
- instead of using just is_int and is_float for checking timestamp, use filter_var since that can detect string ints and floats 
- if its not a string or float, consider it might be a ISO8601 or some other string, so use strtotime() to support other strings