### PR TITLE
Update default consumer

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -31,7 +31,7 @@ class Segment_Client {
 
     # Use our socket consumer by default
     $consumer_type = isset($options["consumer"]) ? $options["consumer"] :
-                                                   "lib_curl";
+                                                   "socket";
     $Consumer = $consumers[$consumer_type];
 
     $this->consumer = new $Consumer($secret, $options);


### PR DESCRIPTION
Makes it consistent with the comment and the last part of [this article](https://segment.com/blog/how-to-make-async-requests-in-php/).

Specifically this point
> Edit 2/6/13: Originally I had stated that we used the curl forking approach for our default and had ignored persistent sockets altoghether. After switching to persistent sockets, the performance of the socket approach increased enough to make it our default approach. It also has better portability across PHP installations.
