### PR TITLE
Fix problem with library version null value if it is used under custom autoloader ( tested with composer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test: install
 
 release:
 	@echo "releasing ${VERSION}..."
-	@echo '<?php $$SEGMENT_VERSION = "${VERSION}"; ?>' > ./lib/Segment/Version.php
+	@echo -e '<?php\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = "${VERSION}";\n?>' > ./lib/Segment/Version.php
 	@node -e "var fs = require('fs'), pkg = require('./composer'); pkg.version = '${VERSION}'; fs.writeFileSync('./composer.json', JSON.stringify(pkg, null, '\t'));"
 	@git changelog -t ${VERSION}
 	@git release ${VERSION}


### PR DESCRIPTION
Hello, Segment!

Currently a project, I'm involved in, having problem with low rate of track events delivery.
During discussion with support team a problem found: there is no library version in event payload.

This PR is going to fix this problem, please consider to merge and release it ASAP.

Thank you in advance!