### PR TITLE
Remove extra -e character in version file

### DIFF
--- a/lib/Segment/Version.php
+++ b/lib/Segment/Version.php
@@ -1,4 +1,4 @@
--e <?php
+<?php
 global $SEGMENT_VERSION;
 $SEGMENT_VERSION = "1.4.1";
 ?>


### PR DESCRIPTION
The recent change in https://github.com/segmentio/analytics-php/commit/67c8668919ef0d19ed87cb2caf3e90134fb8afe1 started showing "-e " at the very beginning of our application (we're using composer).  I don't believe the `-e ` is necessary / maybe was a typo from another command? 