### PR TITLE
Improved portability and reliability of Makefile accros different platforms and shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ test: install
 	@php ./composer.phar validate
 
 release:
-	@echo "releasing ${VERSION}..."
-	@echo '<?php\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = "${VERSION}";\n?>' > ./lib/Segment/Version.php
+	@printf "releasing ${VERSION}..."
+	@printf '<?php\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = "%b";\n?>' ${VERSION} > ./lib/Segment/Version.php
 	@node -e "var fs = require('fs'), pkg = require('./composer'); pkg.version = '${VERSION}'; fs.writeFileSync('./composer.json', JSON.stringify(pkg, null, '\t'));"
 	@git changelog -t ${VERSION}
 	@git release ${VERSION}


### PR DESCRIPTION
Few versions ago there was a problem with generating ```./lib/Segment/Version.php```, that had been solved
in #70 . Also this PR fixed code style for resulting php file.
And while you are running make on Linux , all is ok. But in some shells/Unix vendors , like Mac OS X, there is a portability problem: echo does not support -e option, which led to 
#73 , which fixes problem with not optimal way, cause some shells will print ```\n``` string into php file without escaping it to new line character. 

This could be solved by removing ```\n``` from Makefile, but it won't  stop further problems with echo portability, so in this PR I suggest to fix root of problem via using ```printf``` GNU tool, which is safer.

Please test ```make release test_version``` on Mac OS X.

Related info:
http://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo
http://stackoverflow.com/questions/11675070/makefile-echo-n-not-working
