### PR TITLE
Remove the chmod 777

### DIFF
--- a/lib/Segment/Consumer/File.php
+++ b/lib/Segment/Consumer/File.php
@@ -20,7 +20,6 @@ class Segment_Consumer_File extends Segment_Consumer {
 
     try {
       $this->file_handle = fopen($options["filename"], "a");
-      chmod($options["filename"], 0777);
     } catch (Exception $e) {
       $this->handleError($e->getCode(), $e->getMessage());
     }


### PR DESCRIPTION
This library does not need to set permissions on the file. Sysadmins can manage what permissions should be when the file is created, and what permissions are required for the cron to read/rename/write the file.
