### PR TITLE
Formatting updates

### DIFF
--- a/lib/Segment.php
+++ b/lib/Segment.php
@@ -7,139 +7,165 @@ if (!function_exists('json_encode')) {
 require(dirname(__FILE__) . '/Segment/Client.php');
 
 
-class Segment {
+class Segment
+{
+    /**
+     * @var Segment_Client
+     */
+    private static $client;
 
-  private static $client;
+    /**
+     * Initializes the default client to use. Uses the LibCurl consumer by default
+     *
+     * @param string $secret your project's secret key
+     * @param array $options passed straight to the client
+     */
+    public static function init($secret, $options = array())
+    {
+        self::assert($secret, "Segment::init() requires secret");
+        self::$client = new Segment_Client($secret, $options);
+    }
 
-  /**
-   * Initializes the default client to use. Uses the socket consumer by default.
-   * @param  string $secret   your project's secret key
-   * @param  array  $options  passed straight to the client
-   */
-  public static function init($secret, $options = array()) {
-    self::assert($secret, "Segment::init() requires secret");
-    self::$client = new Segment_Client($secret, $options);
-  }
+    /**
+     * Tracks a user action
+     *
+     * @param array $message
+     *
+     * @return boolean whether the track call succeeded
+     */
+    public static function track(array $message)
+    {
+        self::checkClient();
+        $event = !empty($message["event"]);
+        self::assert($event, "Segment::track() expects an event");
+        self::validate($message, "track");
+        return self::$client->track($message);
+    }
 
-  /**
-   * Tracks a user action
-   *
-   * @param  array $message
-   * @return boolean whether the track call succeeded
-   */
-  public static function track(array $message) {
-    self::checkClient();
-    $event = !empty($message["event"]);
-    self::assert($event, "Segment::track() expects an event");
-    self::validate($message, "track");
-    return self::$client->track($message);
-  }
+    /**
+     * Tags traits about the user
+     *
+     * @param array $message
+     *
+     * @return boolean whether the identify call succeeded
+     */
+    public static function identify(array $message)
+    {
+        self::checkClient();
+        $message["type"] = "identify";
+        self::validate($message, "identify");
+        return self::$client->identify($message);
+    }
 
-  /**
-   * Tags traits about the user.
-   *
-   * @param  array  $message
-   * @return boolean whether the identify call succeeded
-   */
-  public static function identify(array $message) {
-    self::checkClient();
-    $message["type"] = "identify";
-    self::validate($message, "identify");
-    return self::$client->identify($message);
-  }
+    /**
+     * Tags traits about the group
+     *
+     * @param array $message
+     *
+     * @return boolean whether the group call succeeded
+     */
+    public static function group(array $message)
+    {
+        self::checkClient();
+        $groupId = !empty($message["groupId"]);
+        $userId = !empty($message["userId"]);
+        self::assert($groupId && $userId, "Segment::group() expects userId and groupId");
+        return self::$client->group($message);
+    }
 
-  /**
-   * Tags traits about the group.
-   *
-   * @param  array  $message
-   * @return boolean whether the group call succeeded
-   */
-  public static function group(array $message) {
-    self::checkClient();
-    $groupId = !empty($message["groupId"]);
-    $userId = !empty($message["userId"]);
-    self::assert($groupId && $userId, "Segment::group() expects userId and groupId");
-    return self::$client->group($message);
-  }
+    /**
+     * Tracks a page view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the page call succeeded
+     */
+    public static function page(array $message)
+    {
+        self::checkClient();
+        self::validate($message, "page");
+        return self::$client->page($message);
+    }
 
-  /**
-   * Tracks a page view
-   *
-   * @param  array $message
-   * @return boolean whether the page call succeeded
-   */
-  public static function page(array $message) {
-    self::checkClient();
-    self::validate($message, "page");
-    return self::$client->page($message);
-  }
+    /**
+     * Tracks a screen view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the screen call succeeded
+     */
+    public static function screen(array $message)
+    {
+        self::checkClient();
+        self::validate($message, "screen");
+        return self::$client->screen($message);
+    }
 
-  /**
-   * Tracks a screen view
-   *
-   * @param  array $message
-   * @return boolean whether the screen call succeeded
-   */
-  public static function screen(array $message) {
-    self::checkClient();
-    self::validate($message, "screen");
-    return self::$client->screen($message);
-  }
+    /**
+     * Aliases the user id from a temporary id to a permanent one
+     *
+     * @param array $message
+     *
+     * @return boolean whether the alias call succeeded
+     */
+    public static function alias(array $message)
+    {
+        self::checkClient();
+        $userId = !empty($message["userId"]);
+        $previousId = !empty($message["previousId"]);
+        self::assert($userId && $previousId, "Segment::alias() requires both userId and previousId");
+        return self::$client->alias($message);
+    }
 
-  /**
-   * Aliases the user id from a temporary id to a permanent one
-   *
-   * @param  array $from      user id to alias from
-   * @return boolean whether the alias call succeeded
-   */
-  public static function alias(array $message) {
-    self::checkClient();
-    $userId = !empty($message["userId"]);
-    $previousId = !empty($message["previousId"]);
-    self::assert($userId && $previousId, "Segment::alias() requires both userId and previousId");
-    return self::$client->alias($message);
-  }
+    /**
+     * Validate common properties
+     *
+     * @param array $msg
+     * @param string $type
+     */
+    public static function validate($msg, $type)
+    {
+        $userId = !empty($msg["userId"]);
+        $anonId = !empty($msg["anonymousId"]);
+        self::assert($userId || $anonId, "Segment::$type() requires userId or anonymousId");
+    }
 
-  /**
-   * Validate common properties.
-   *
-   * @param array $msg
-   * @param string $type
-   */
-  public static function validate($msg, $type){
-    $userId = !empty($msg["userId"]);
-    $anonId = !empty($msg["anonymousId"]);
-    self::assert($userId || $anonId, "Segment::$type() requires userId or anonymousId");
-  }
+    /**
+     * Flush the client
+     */
+    public static function flush()
+    {
+        self::checkClient();
+        return self::$client->flush();
+    }
 
-  /**
-   * Flush the client
-   */
+    /**
+     * Check the client.
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    private static function checkClient()
+    {
+        if (null != self::$client) {
+            return;
+        }
+        throw new Exception("Segment::init() must be called before any other tracking method.");
+    }
 
-  public static function flush(){
-    self::checkClient();
-    return self::$client->flush();
-  }
-
-  /**
-   * Check the client.
-   *
-   * @throws Exception
-   */
-  private static function checkClient(){
-    if (null != self::$client) return;
-    throw new Exception("Segment::init() must be called before any other tracking method.");
-  }
-
-  /**
-   * Assert `value` or throw.
-   *
-   * @param array $value
-   * @param string $msg
-   * @throws Exception
-   */
-  private static function assert($value, $msg){
-    if (!$value) throw new Exception($msg);
-  }
-
+    /**
+     * Assert `value` or throw.
+     *
+     * @param array $value
+     * @param string $msg
+     *
+     * @throws Exception
+     */
+    private static function assert($value, $msg)
+    {
+        if (!$value) {
+            throw new Exception($msg);
+        }
+    }
 }

--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -8,210 +8,250 @@ require(__DIR__ . '/Consumer/LibCurl.php');
 require(__DIR__ . '/Consumer/Socket.php');
 require(__DIR__ . '/Version.php');
 
-class Segment_Client {
+class Segment_Client
+{
+    /**
+     * @var Segment_Consumer
+     */
+    protected $consumer;
 
-  protected $consumer;
+    /**
+     * Create a new analytics object with your app's secret
+     * key
+     *
+     * @param string $secret
+     * @param array $options array of consumer options [optional]
+     *  @param string "consumer" constructor to use, LibCurl by default.
+     */
+    public function __construct($secret, $options = array())
+    {
+        $consumers = array(
+            "socket" => "Segment_Consumer_Socket",
+            "file" => "Segment_Consumer_File",
+            "fork_curl" => "Segment_Consumer_ForkCurl",
+            "lib_curl" => "Segment_Consumer_LibCurl"
+        );
 
-  /**
-   * Create a new analytics object with your app's secret
-   * key
-   *
-   * @param string $secret
-   * @param array  $options array of consumer options [optional]
-   * @param string Consumer constructor to use, socket by default.
-   */
-  public function __construct($secret, $options = array()) {
+        # Use our socket consumer by default
+        $consumer_type = isset($options["consumer"]) ? $options["consumer"] : "lib_curl";
+        $consumer = $consumers[$consumer_type];
 
-    $consumers = array(
-      "socket"     => "Segment_Consumer_Socket",
-      "file"       => "Segment_Consumer_File",
-      "fork_curl"  => "Segment_Consumer_ForkCurl",
-      "lib_curl"   => "Segment_Consumer_LibCurl"
-    );
-
-    # Use our socket consumer by default
-    $consumer_type = isset($options["consumer"]) ? $options["consumer"] :
-                                                   "lib_curl";
-    $Consumer = $consumers[$consumer_type];
-
-    $this->consumer = new $Consumer($secret, $options);
-  }
-
-  public function __destruct() {
-    $this->consumer->__destruct();
-  }
-
-  /**
-   * Tracks a user action
-   *
-   * @param  array $message
-   * @return [boolean] whether the track call succeeded
-   */
-  public function track(array $message) {
-    $message = $this->message($message, "properties");
-    $message["type"] = "track";
-    return $this->consumer->track($message);
-  }
-
-  /**
-   * Tags traits about the user.
-   *
-   * @param  [array] $message
-   * @return [boolean] whether the track call succeeded
-   */
-  public function identify(array $message) {
-    $message = $this->message($message, "traits");
-    $message["type"] = "identify";
-    return $this->consumer->identify($message);
-  }
-
-  /**
-   * Tags traits about the group.
-   *
-   * @param  [array] $message
-   * @return [boolean] whether the group call succeeded
-   */
-  public function group(array $message) {
-    $message = $this->message($message, "traits");
-    $message["type"] = "group";
-    return $this->consumer->group($message);
-  }
-
-  /**
-   * Tracks a page view.
-   *
-   * @param  [array] $message
-   * @return [boolean] whether the page call succeeded
-   */
-  public function page(array $message) {
-    $message = $this->message($message, "properties");
-    $message["type"] = "page";
-    return $this->consumer->page($message);
-  }
-
-  /**
-   * Tracks a screen view.
-   *
-   * @param  [array] $message
-   * @return [boolean] whether the screen call succeeded
-   */
-  public function screen(array $message) {
-    $message = $this->message($message, "properties");
-    $message["type"] = "screen";
-    return $this->consumer->screen($message);
-  }
-
-  /**
-   * Aliases from one user id to another
-   *
-   * @param  array $message
-   * @return boolean whether the alias call succeeded
-   */
-  public function alias(array $message) {
-    $message = $this->message($message);
-    $message["type"] = "alias";
-    return $this->consumer->alias($message);
-  }
-
-  /**
-   * Flush any async consumers
-   * @return boolean true if flushed successfully
-   */
-  public function flush() {
-    if (method_exists($this->consumer, 'flush')) {
-      return $this->consumer->flush();
-    }
-    return true;
-  }
-
-  /**
-   * Formats a timestamp by making sure it is set
-   * and converting it to iso8601.
-   *
-   * The timestamp can be time in seconds `time()` or `microseconds(true)`.
-   * any other input is considered an error and the method will return a new date.
-   *
-   * Note: php's date() "u" format (for microseconds) has a bug in it
-   * it always shows `.000` for microseconds since `date()` only accepts
-   * ints, so we have to construct the date ourselves if microtime is passed.
-   *
-   * @param  time $timestamp - time in seconds (time())
-   */
-  private function formatTime($ts) {
-    // time()
-    if ($ts == null || !$ts) $ts = time();
-    if (filter_var($ts, FILTER_VALIDATE_INT) !== false) return date("c", (int) $ts);
-
-    // anything else try to strtotime the date.
-    if (filter_var($ts, FILTER_VALIDATE_FLOAT) === false) {
-      if (is_string($ts)) {
-        return date("c", strtotime($ts));
-      } else {
-        return date("c");
-      }
+        $this->consumer = new $consumer($secret, $options);
     }
 
-    // fix for floatval casting in send.php
-    $parts = explode(".", (string)$ts);
-    if (!isset($parts[1])) return date("c", (int)$parts[0]);
+    /**
+     * Call the consumer's __destruct function once this object is no longer referenced
+     */
+    public function __destruct()
+    {
+        $this->consumer->__destruct();
+    }
 
-    // microtime(true)
-    $sec = (int)$parts[0];
-    $usec = (int)$parts[1];
-    $fmt = sprintf("Y-m-d\TH:i:s%sP", $usec);
-    return date($fmt, (int)$sec);
-  }
+    /**
+     * Tracks a user action
+     *
+     * @param array $message
+     *
+     * @return boolean whether the track call succeeded
+     */
+    public function track(array $message)
+    {
+        $message = $this->message($message, "properties");
+        $message["type"] = "track";
+        return $this->consumer->track($message);
+    }
 
-  /**
-   * Add common fields to the gvien `message`
-   *
-   * @param array $msg
-   * @param string $def
-   * @return array
-   */
+    /**
+     * Tags traits about the user
+     *
+     * @param array $message
+     *
+     * @return boolean whether the track call succeeded
+     */
+    public function identify(array $message)
+    {
+        $message = $this->message($message, "traits");
+        $message["type"] = "identify";
+        return $this->consumer->identify($message);
+    }
 
-  private function message($msg, $def = ""){
-    if ($def && !isset($msg[$def])) $msg[$def] = array();
-    if ($def && empty($msg[$def])) $msg[$def] = (object)$msg[$def];
-    if (!isset($msg["context"])) $msg["context"] = array();
-    if (!isset($msg["timestamp"])) $msg["timestamp"] = null;
-    $msg["context"] = array_merge($msg["context"], $this->getContext());
-    $msg["timestamp"] = $this->formatTime($msg["timestamp"]);
-    $msg["messageId"] = self::messageId();
-    return $msg;
-  }
+    /**
+     * Tags traits about the group
+     *
+     * @param array $message
+     *
+     * @return boolean whether the group call succeeded
+     */
+    public function group(array $message)
+    {
+        $message = $this->message($message, "traits");
+        $message["type"] = "group";
+        return $this->consumer->group($message);
+    }
 
-  /**
-   * Generate a random messageId.
-   *
-   * https://gist.github.com/dahnielson/508447#file-uuid-php-L74
-   *
-   * @return string
-   */
+    /**
+     * Tracks a page view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the page call succeeded
+     */
+    public function page(array $message)
+    {
+        $message = $this->message($message, "properties");
+        $message["type"] = "page";
+        return $this->consumer->page($message);
+    }
 
-  private static function messageId(){
-    return sprintf("%04x%04x-%04x-%04x-%04x-%04x%04x%04x"
-      , mt_rand(0, 0xffff)
-      , mt_rand(0, 0xffff)
-      , mt_rand(0, 0xffff)
-      , mt_rand(0, 0x0fff) | 0x4000
-      , mt_rand(0, 0x3fff) | 0x8000
-      , mt_rand(0, 0xffff)
-      , mt_rand(0, 0xffff)
-      , mt_rand(0, 0xffff));
-  }
+    /**
+     * Tracks a screen view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the screen call succeeded
+     */
+    public function screen(array $message)
+    {
+        $message = $this->message($message, "properties");
+        $message["type"] = "screen";
+        return $this->consumer->screen($message);
+    }
 
-  /**
-   * Add the segment.io context to the request
-   * @return array additional context
-   */
-  private function getContext () {
-    global $SEGMENT_VERSION;
-    return array(
-      "library" => array(
-        "name" => "analytics-php",
-        "version" => $SEGMENT_VERSION
-      )
-    );
-  }
+    /**
+     * Aliases from one user id to another
+     *
+     * @param array $message
+     *
+     * @return boolean whether the alias call succeeded
+     */
+    public function alias(array $message)
+    {
+        $message = $this->message($message);
+        $message["type"] = "alias";
+        return $this->consumer->alias($message);
+    }
+
+    /**
+     * Flush any async consumers
+     *
+     * @return boolean true if flushed successfully
+     */
+    public function flush()
+    {
+        if (method_exists($this->consumer, 'flush')) {
+            return $this->consumer->flush();
+        }
+        return true;
+    }
+
+    /**
+     * Formats a timestamp by making sure it is set
+     * and converting it to iso8601.
+     *
+     * The timestamp can be time in seconds `time()` or `microseconds(true)`.
+     * any other input is considered an error and the method will return a new date.
+     *
+     * Note: php's date() "u" format (for microseconds) has a bug in it
+     * it always shows `.000` for microseconds since `date()` only accepts
+     * ints, so we have to construct the date ourselves if microtime is passed.
+     *
+     * @param string $ts time in seconds (time())
+     *
+     * @return string
+     */
+    private function formatTime($ts)
+    {
+        // time()
+        if ($ts == null || !$ts) {
+            $ts = time();
+        }
+        if (filter_var($ts, FILTER_VALIDATE_INT) !== false) {
+            return date("c", (int)$ts);
+        }
+
+        // anything else try to strtotime the date.
+        if (filter_var($ts, FILTER_VALIDATE_FLOAT) === false) {
+            if (is_string($ts)) {
+                return date("c", strtotime($ts));
+            } else {
+                return date("c");
+            }
+        }
+
+        // fix for floatval casting in send.php
+        $parts = explode(".", (string)$ts);
+        if (!isset($parts[1])) {
+            return date("c", (int)$parts[0]);
+        }
+
+        // microtime(true)
+        $sec = (int)$parts[0];
+        $usec = (int)$parts[1];
+        $fmt = sprintf("Y-m-d\TH:i:s%sP", $usec);
+        return date($fmt, (int)$sec);
+    }
+
+    /**
+     * Add common fields to the gvien `message`
+     *
+     * @param array $msg
+     * @param string $def
+     * @return array
+     */
+
+    private function message($msg, $def = "")
+    {
+        if ($def && !isset($msg[$def])) {
+            $msg[$def] = array();
+        }
+        if ($def && empty($msg[$def])) {
+            $msg[$def] = (object)$msg[$def];
+        }
+        if (!isset($msg["context"])) {
+            $msg["context"] = array();
+        }
+        if (!isset($msg["timestamp"])) {
+            $msg["timestamp"] = null;
+        }
+        $msg["context"] = array_merge($msg["context"], $this->getContext());
+        $msg["timestamp"] = $this->formatTime($msg["timestamp"]);
+        $msg["messageId"] = self::messageId();
+        return $msg;
+    }
+
+    /**
+     * Generate a random messageId
+     *
+     * https://gist.github.com/dahnielson/508447#file-uuid-php-L74
+     *
+     * @return string
+     */
+    private static function messageId()
+    {
+        return sprintf("%04x%04x-%04x-%04x-%04x-%04x%04x%04x"
+            , mt_rand(0, 0xffff)
+            , mt_rand(0, 0xffff)
+            , mt_rand(0, 0xffff)
+            , mt_rand(0, 0x0fff) | 0x4000
+            , mt_rand(0, 0x3fff) | 0x8000
+            , mt_rand(0, 0xffff)
+            , mt_rand(0, 0xffff)
+            , mt_rand(0, 0xffff));
+    }
+
+    /**
+     * Add the segment.io context to the request
+     *
+     * @return array additional context
+     */
+    private function getContext()
+    {
+        global $SEGMENT_VERSION;
+        return array(
+            "library" => array(
+                "name" => "analytics-php",
+                "version" => $SEGMENT_VERSION
+            )
+        );
+    }
 }

--- a/lib/Segment/Consumer.php
+++ b/lib/Segment/Consumer.php
@@ -1,104 +1,134 @@
 <?php
-abstract class Segment_Consumer {
 
-  protected $type = "Consumer";
+abstract class Segment_Consumer
+{
+    /**
+     * @var string
+     */
+    protected $type = "Consumer";
 
-  protected $options;
-  protected $secret;
+    /**
+     * @var array
+     */
+    protected $options;
 
-  /**
-   * Store our secret and options as part of this consumer
-   * @param string $secret
-   * @param array  $options
-   */
-  public function __construct($secret, $options = array()) {
-    $this->secret = $secret;
-    $this->options = $options;
-  }
+    /**
+     * @var string
+     */
+    protected $secret;
 
-
-  /**
-   * Tracks a user action
-   *
-   * @param  array  $message
-   * @return boolean whether the track call succeeded
-   */
-  abstract public function track(array $message);
-
-  /**
-   * Tags traits about the user.
-   *
-   * @param  array  $message
-   * @return boolean whether the identify call succeeded
-   */
-  abstract public function identify(array $message);
-
-  /**
-   * Tags traits about the group.
-   *
-   * @param  array  $message
-   * @return boolean whether the group call succeeded
-   */
-  abstract public function group(array $message);
-
-  /**
-   * Tracks a page view.
-   *
-   * @param  array  $message
-   * @return boolean whether the page call succeeded
-   */
-  abstract public function page(array $message);
-
-  /**
-   * Tracks a screen view.
-   *
-   * @param  array  $message
-   * @return boolean whether the group call succeeded
-   */
-  abstract public function screen(array $message);
-
-  /**
-   * Aliases from one user id to another
-   *
-   * @param  array $message
-   * @return boolean whether the alias call succeeded
-   */
-  abstract public function alias(array $message);
-
-  /**
-   * Check whether debug mode is enabled
-   * @return boolean
-   */
-  protected function debug() {
-    return isset($this->options["debug"]) ? $this->options["debug"] : false;
-  }
-
-  /**
-   * Check whether we should connect to the API using SSL. This is enabled by
-   * default with connections which make batching requests. For connections
-   * which can save on round-trip times, you may disable it.
-   * @return boolean
-   */
-  protected function ssl() {
-    return isset($this->options["ssl"]) ? $this->options["ssl"] : true;
-  }
-
-
-  /**
-   * On an error, try and call the error handler, if debugging output to
-   * error_log as well.
-   * @param  string $code
-   * @param  string $msg
-   */
-  protected function handleError($code, $msg) {
-
-    if (isset($this->options['error_handler'])) {
-      $handler = $this->options['error_handler'];
-      $handler($code, $msg);
+    /**
+     * Store our secret and options as part of this consumer
+     *
+     * @param string $secret
+     * @param array $options
+     */
+    public function __construct($secret, $options = array())
+    {
+        $this->secret = $secret;
+        $this->options = $options;
     }
 
-    if ($this->debug()) {
-      error_log("[Analytics][" . $this->type . "] " . $msg);
+    /**
+     * Base method with nothing to do
+     */
+    public function __destruct()
+    {
     }
-  }
+
+    /**
+     * Tracks a user action
+     *
+     * @param array $message
+     *
+     * @return boolean whether the track call succeeded
+     */
+    abstract public function track(array $message);
+
+    /**
+     * Tags traits about the user
+     *
+     * @param array $message
+     *
+     * @return boolean whether the identify call succeeded
+     */
+    abstract public function identify(array $message);
+
+    /**
+     * Tags traits about the group
+     *
+     * @param array $message
+     *
+     * @return boolean whether the group call succeeded
+     */
+    abstract public function group(array $message);
+
+    /**
+     * Tracks a page view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the page call succeeded
+     */
+    abstract public function page(array $message);
+
+    /**
+     * Tracks a screen view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the group call succeeded
+     */
+    abstract public function screen(array $message);
+
+    /**
+     * Aliases from one user id to another
+     *
+     * @param array $message
+     *
+     * @return boolean whether the alias call succeeded
+     */
+    abstract public function alias(array $message);
+
+    /**
+     * Check whether debug mode is enabled
+     *
+     * @return boolean
+     */
+    protected function debug()
+    {
+        return isset($this->options["debug"]) ? $this->options["debug"] : false;
+    }
+
+    /**
+     * Check whether we should connect to the API using SSL. This is enabled by
+     * default with connections which make batching requests. For connections
+     * which can save on round-trip times, you may disable it
+     *
+     * @return boolean
+     */
+    protected function ssl()
+    {
+        return isset($this->options["ssl"]) ? $this->options["ssl"] : true;
+    }
+
+
+    /**
+     * On an error, try and call the error handler, if debugging output to
+     * error_log as well
+     *
+     * @param string $code
+     * @param string $msg
+     */
+    protected function handleError($code, $msg)
+    {
+        if (isset($this->options['error_handler'])) {
+            $handler = $this->options['error_handler'];
+            $handler($code, $msg);
+        }
+
+        if ($this->debug()) {
+            error_log("[Analytics][" . $this->type . "] " . $msg);
+        }
+    }
 }

--- a/lib/Segment/Consumer/File.php
+++ b/lib/Segment/Consumer/File.php
@@ -1,111 +1,139 @@
 <?php
 
-class Segment_Consumer_File extends Segment_Consumer {
+class Segment_Consumer_File extends Segment_Consumer
+{
+    /**
+     * @var resource
+     */
+    private $file_handle;
 
-  private $file_handle;
-  protected $type = "File";
+    /**
+     * @var string
+     */
+    protected $type = "File";
 
-  /**
-   * The file consumer writes track and identify calls to a file.
-   * @param string $secret
-   * @param array  $options
-   *     string "filename" - where to log the analytics calls
-   */
-  public function __construct($secret, $options = array()) {
+    /**
+     * The file consumer writes track and identify calls to a file
+     *
+     * @param string $secret
+     * @param array $options
+     *     string "filename" - where to log the analytics calls
+     */
+    public function __construct($secret, $options = array())
+    {
 
-    if (!isset($options["filename"]))
-      $options["filename"] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "analytics.log";
+        if (!isset($options["filename"])) {
+            $options["filename"] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "analytics.log";
+        }
 
-    parent::__construct($secret, $options);
+        parent::__construct($secret, $options);
 
-    try {
-      $this->file_handle = fopen($options["filename"], "a");
-      chmod($options["filename"], 0777);
-    } catch (Exception $e) {
-      $this->handleError($e->getCode(), $e->getMessage());
+        try {
+            $this->file_handle = fopen($options["filename"], "a");
+            chmod($options["filename"], 0777);
+        } catch (Exception $e) {
+            $this->handleError($e->getCode(), $e->getMessage());
+        }
     }
-  }
 
-  public function __destruct() {
-    if ($this->file_handle &&
-        get_resource_type($this->file_handle) != "Unknown") {
-      fclose($this->file_handle);
+    public function __destruct()
+    {
+        if ($this->file_handle &&
+            get_resource_type($this->file_handle) != "Unknown"
+        ) {
+            fclose($this->file_handle);
+        }
     }
-  }
 
-  /**
-   * Tracks a user action
-   * 
-   * @param  array $message
-   * @return [boolean] whether the track call succeeded
-   */
-  public function track(array $message) {
-    return $this->write($message);
-  }
+    /**
+     * Tracks a user action
+     *
+     * @param  array $message
+     *
+     * @return boolean whether the track call succeeded
+     */
+    public function track(array $message)
+    {
+        return $this->write($message);
+    }
 
-  /**
-   * Tags traits about the user.
-   * 
-   * @param  array $message
-   * @return [boolean] whether the identify call succeeded
-   */
-  public function identify(array $message) {
-    return $this->write($message);
-  }
+    /**
+     * Tags traits about the user
+     *
+     * @param array $message
+     *
+     * @return boolean whether the identify call succeeded
+     */
+    public function identify(array $message)
+    {
+        return $this->write($message);
+    }
 
-  /**
-   * Tags traits about the group.
-   * 
-   * @param  array $message
-   * @return [boolean] whether the group call succeeded
-   */
-  public function group(array $message) {
-    return $this->write($message);
-  }
+    /**
+     * Tags traits about the group
+     *
+     * @param array $message
+     *
+     * @return boolean whether the group call succeeded
+     */
+    public function group(array $message)
+    {
+        return $this->write($message);
+    }
 
-  /**
-   * Tracks a page view.
-   * 
-   * @param  array $message
-   * @return [boolean] whether the page call succeeded
-   */
-  public function page(array $message) {
-    return $this->write($message);
-  }
+    /**
+     * Tracks a page view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the page call succeeded
+     */
+    public function page(array $message)
+    {
+        return $this->write($message);
+    }
 
-  /**
-   * Tracks a screen view.
-   * 
-   * @param  array $message
-   * @return [boolean] whether the screen call succeeded
-   */
-  public function screen(array $message) {
-    return $this->write($message);
-  }
+    /**
+     * Tracks a screen view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the screen call succeeded
+     */
+    public function screen(array $message)
+    {
+        return $this->write($message);
+    }
 
-  /**
-   * Aliases from one user id to another
-   * 
-   * @param  array $message
-   * @return boolean whether the alias call succeeded
-   */
-  public function alias(array $message) {
-    return $this->write($message);
-  }
+    /**
+     * Aliases from one user id to another
+     *
+     * @param array $message
+     *
+     * @return boolean whether the alias call succeeded
+     */
+    public function alias(array $message)
+    {
+        return $this->write($message);
+    }
 
-  /**
-   * Writes the API call to a file as line-delimited json
-   * @param  [array]   $body post body content.
-   * @return [boolean] whether the request succeeded
-   */
-  private function write($body) {
+    /**
+     * Writes the API call to a file as line-delimited json
+     *
+     * @param array $body post body content
+     *
+     * @return boolean whether the request succeeded
+     */
+    private function write($body)
+    {
 
-    if (!$this->file_handle)
-      return false;
+        if (!$this->file_handle) {
+            return false;
+        }
 
-    $content = json_encode($body);
-    $content.= "\n";
+        $content = json_encode($body);
+        $content .= "\n";
 
-    return fwrite($this->file_handle, $content) == strlen($content);
-  }
+        return fwrite($this->file_handle, $content) == strlen($content);
+    }
 }

--- a/lib/Segment/Consumer/ForkCurl.php
+++ b/lib/Segment/Consumer/ForkCurl.php
@@ -1,56 +1,63 @@
 <?php
 
-class Segment_Consumer_ForkCurl extends Segment_QueueConsumer {
+class Segment_Consumer_ForkCurl extends Segment_QueueConsumer
+{
+    /**
+     * @var string
+     */
+    protected $type = "ForkCurl";
 
-  protected $type = "ForkCurl";
-
-
-  /**
-   * Creates a new queued fork consumer which queues fork and identify
-   * calls before adding them to
-   * @param string $secret
-   * @param array  $options
-   *     boolean  "debug" - whether to use debug output, wait for response.
-   *     number   "max_queue_size" - the max size of messages to enqueue
-   *     number   "batch_size" - how many messages to send in a single request
-   */
-  public function __construct($secret, $options = array()) {
-    parent::__construct($secret, $options);
-  }
-
-  /**
-   * Make an async request to our API. Fork a curl process, immediately send
-   * to the API. If debug is enabled, we wait for the response.
-   * @param  array   $messages array of all the messages to send
-   * @return boolean whether the request succeeded
-   */
-  public function flushBatch($messages) {
-
-    $body = $this->payload($messages);
-    $payload = json_encode($body);
-
-    # Escape for shell usage.
-    $payload = escapeshellarg($payload);
-    $secret = $this->secret;
-
-    $protocol = $this->ssl() ? "https://" : "http://";
-    $host = "api.segment.io";
-    $path = "/v1/import";
-    $url = $protocol . $host . $path;
-
-    $cmd = "curl -u $secret: -X POST -H 'Content-Type: application/json'";
-    $cmd.= " -d " . $payload . " '" . $url . "'";
-
-    if (!$this->debug()) {
-      $cmd .= " > /dev/null 2>&1 &";
+    /**
+     * Creates a new queued fork consumer which queues fork and identify
+     * calls before adding them to
+     *
+     * @param string $secret
+     * @param array $options
+     *     boolean  "debug" - whether to use debug output, wait for response
+     *     number   "max_queue_size" - the max size of messages to enqueue
+     *     number   "batch_size" - how many messages to send in a single request
+     */
+    public function __construct($secret, $options = array())
+    {
+        parent::__construct($secret, $options);
     }
 
-    exec($cmd, $output, $exit);
+    /**
+     * Make an async request to our API. Fork a curl process, immediately send
+     * to the API. If debug is enabled, we wait for the response
+     *
+     * @param array $messages array of all the messages to send
+     *
+     * @return boolean whether the request succeeded
+     */
+    public function flushBatch($messages)
+    {
 
-    if ($exit != 0) {
-      $this->handleError($exit, $output);
+        $body = $this->payload($messages);
+        $payload = json_encode($body);
+
+        # Escape for shell usage.
+        $payload = escapeshellarg($payload);
+        $secret = $this->secret;
+
+        $protocol = $this->ssl() ? "https://" : "http://";
+        $host = "api.segment.io";
+        $path = "/v1/import";
+        $url = $protocol . $host . $path;
+
+        $cmd = "curl -u $secret: -X POST -H 'Content-Type: application/json'";
+        $cmd .= " -d " . $payload . " '" . $url . "'";
+
+        if (!$this->debug()) {
+            $cmd .= " > /dev/null 2>&1 &";
+        }
+
+        exec($cmd, $output, $exit);
+
+        if ($exit != 0) {
+            $this->handleError($exit, $output);
+        }
+
+        return $exit == 0;
     }
-
-    return $exit == 0;
-  }
 }

--- a/lib/Segment/Consumer/LibCurl.php
+++ b/lib/Segment/Consumer/LibCurl.php
@@ -1,69 +1,76 @@
 <?php
 
-class Segment_Consumer_LibCurl extends Segment_QueueConsumer {
+class Segment_Consumer_LibCurl extends Segment_QueueConsumer
+{
+    /**
+     * @var string
+     */
+    protected $type = "LibCurl";
 
-  protected $type = "LibCurl";
-
-  /**
-   * Creates a new queued fork consumer which queues fork and identify
-   * calls before adding them to
-   * @param string $secret
-   * @param array  $options
-   *     boolean  "debug" - whether to use debug output, wait for response.
-   *     number   "max_queue_size" - the max size of messages to enqueue
-   *     number   "batch_size" - how many messages to send in a single request
-   */
-  public function __construct($secret, $options = array()) {
-    parent::__construct($secret, $options);
-  }
-
-  /**
-   * Make an async request to our API. Fork a curl process, immediately send
-   * to the API. If debug is enabled, we wait for the response.
-   * @param  array   $messages array of all the messages to send
-   * @return boolean whether the request succeeded
-   */
-  public function flushBatch($messages) {
-
-    $body = $this->payload($messages);
-    $payload = json_encode($body);
-    $secret = $this->secret;
-
-    $protocol = $this->ssl() ? "https://" : "http://";
-    $host = "api.segment.io";
-    $path = "/v1/import";
-    $url = $protocol . $host . $path;
-
-    // open connection
-    $ch = curl_init();
-
-    // set the url, number of POST vars, POST data
-    curl_setopt($ch, CURLOPT_USERPWD, $secret . ':');
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-
-    // set variables for headers
-    $header = array();
-    $header[] = 'Content-Type: application/json';
-
-    curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-
-    // execute post
-    curl_exec($ch);
-
-    if ($this->debug()) {
-
-      $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-      if ($httpCode != 200) {
-        $this->handleError($ch, $httpCode);
-      }
-
-      return $httpCode;
+    /**
+     * Creates a new queued fork consumer which queues fork and identify
+     * calls before adding them to
+     *
+     * @param string $secret
+     * @param array $options
+     *     boolean  "debug" - whether to use debug output, wait for response
+     *     number   "max_queue_size" - the max size of messages to enqueue
+     *     number   "batch_size" - how many messages to send in a single request
+     */
+    public function __construct($secret, $options = array())
+    {
+        parent::__construct($secret, $options);
     }
 
-    //close connection
-    curl_close($ch);
-  }
+    /**
+     * Make an async request to our API. Fork a curl process, immediately send
+     * to the API. If debug is enabled, we wait for the response
+     * 
+     * @param array $messages array of all the messages to send
+     *
+     * @return boolean whether the request succeeded
+     */
+    public function flushBatch($messages)
+    {
+        $body = $this->payload($messages);
+        $payload = json_encode($body);
+        $secret = $this->secret;
+
+        $protocol = $this->ssl() ? "https://" : "http://";
+        $host = "api.segment.io";
+        $path = "/v1/import";
+        $url = $protocol . $host . $path;
+
+        // open connection
+        $ch = curl_init();
+
+        // set the url, number of POST vars, POST data
+        curl_setopt($ch, CURLOPT_USERPWD, $secret . ':');
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+
+        // set variables for headers
+        $header = array();
+        $header[] = 'Content-Type: application/json';
+
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        // execute post
+        curl_exec($ch);
+
+        if ($this->debug()) {
+
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+            if ($httpCode != 200) {
+                $this->handleError($ch, $httpCode);
+            }
+
+            return $httpCode;
+        }
+
+        //close connection
+        curl_close($ch);
+    }
 }

--- a/lib/Segment/Consumer/Socket.php
+++ b/lib/Segment/Consumer/Socket.php
@@ -1,181 +1,216 @@
 <?php
 
-class Segment_Consumer_Socket extends Segment_QueueConsumer {
+class Segment_Consumer_Socket extends Segment_QueueConsumer
+{
+    /**
+     * @var string
+     */
+    protected $type = "Socket";
 
-  protected $type = "Socket";
-  private $socket_failed;
+    /**
+     * @var boolean
+     */
+    private $socket_failed;
 
-  /**
-   * Creates a new socket consumer for dispatching async requests immediately
-   * @param string $secret
-   * @param array  $options
-   *     number   "timeout" - the timeout for connecting
-   *     function "error_handler" - function called back on errors.
-   *     boolean  "debug" - whether to use debug output, wait for response.
-   */
-  public function __construct($secret, $options = array()) {
+    /**
+     * Creates a new socket consumer for dispatching async requests immediately
+     *
+     * @param string $secret
+     * @param array $options
+     *     number   "timeout" - the timeout for connecting
+     *     function "error_handler" - function called back on errors
+     *     boolean  "debug" - whether to use debug output, wait for response
+     */
+    public function __construct($secret, $options = array())
+    {
 
-    if (!isset($options["timeout"]))
-      $options["timeout"] = 5;
+        if (!isset($options["timeout"])) {
+            $options["timeout"] = 5;
+        }
 
-    if (!isset($options["host"]))
-      $options["host"] = "api.segment.io";
+        if (!isset($options["host"])) {
+            $options["host"] = "api.segment.io";
+        }
 
-    parent::__construct($secret, $options);
-  }
-
-
-  public function flushBatch($batch) {
-    $socket = $this->createSocket();
-
-    if (!$socket)
-      return;
-
-    $payload = $this->payload($batch);
-    $payload = json_encode($payload);
-
-    $body = $this->createBody($this->options["host"], $payload);
-    return $this->makeRequest($socket, $body);
-  }
-
-
-  private function createSocket() {
-
-    if ($this->socket_failed)
-      return false;
-
-    $protocol = $this->ssl() ? "ssl" : "tcp";
-    $host = $this->options["host"];
-    $port = $this->ssl() ? 443 : 80;
-    $timeout = $this->options["timeout"];
-
-    try {
-      # Open our socket to the API Server.
-      # Since we're try catch'ing prevent PHP logs.
-      $socket = @pfsockopen($protocol . "://" . $host, $port, $errno,
-                           $errstr, $timeout);
-
-      # If we couldn't open the socket, handle the error.
-      if (false === $socket) {
-        $this->handleError($errno, $errstr);
-        $this->socket_failed = true;
-        return false;
-      }
-
-      return $socket;
-
-    } catch (Exception $e) {
-      $this->handleError($e->getCode(), $e->getMessage());
-      $this->socket_failed = true;
-      return false;
-    }
-  }
-
-  /**
-   * Attempt to write the request to the socket, wait for response if debug
-   * mode is enabled.
-   * @param  stream  $socket the handle for the socket
-   * @param  string  $req    request body
-   * @return boolean $success
-   */
-  private function makeRequest($socket, $req, $retry = true) {
-
-    $bytes_written = 0;
-    $bytes_total = strlen($req);
-    $closed = false;
-
-    # Write the request
-    while (!$closed && $bytes_written < $bytes_total) {
-      try {
-        # Since we're try catch'ing prevent PHP logs.
-        $written = @fwrite($socket, substr($req, $bytes_written));
-      } catch (Exception $e) {
-        $this->handleError($e->getCode(), $e->getMessage());
-        $closed = true;
-      }
-      if (!isset($written) || !$written) {
-        $closed = true;
-      } else {
-        $bytes_written += $written;
-      }
+        parent::__construct($secret, $options);
     }
 
-    # If the socket has been closed, attempt to retry a single time.
-    if ($closed) {
-      fclose($socket);
-
-      if ($retry) {
+    /**
+     * Flushes a batch of messages
+     *
+     * @param array $batch array of all the messages to send
+     *
+     * @return boolean|void
+     */
+    public function flushBatch($batch)
+    {
         $socket = $this->createSocket();
-        if ($socket) return $this->makeRequest($socket, $req, false);
-      }
-      return false;
+
+        if (!$socket) {
+            return;
+        }
+
+        $payload = $this->payload($batch);
+        $payload = json_encode($payload);
+
+        $body = $this->createBody($this->options["host"], $payload);
+        return $this->makeRequest($socket, $body);
     }
 
+    /**
+     * Attempts to create a socket to send events through
+     *
+     * @return boolean|resource
+     */
+    private function createSocket()
+    {
 
-    $success = true;
+        if ($this->socket_failed) {
+            return false;
+        }
 
-    if ($this->debug()) {
-      $res = $this->parseResponse(fread($socket, 2048));
+        $protocol = $this->ssl() ? "ssl" : "tcp";
+        $host = $this->options["host"];
+        $port = $this->ssl() ? 443 : 80;
+        $timeout = $this->options["timeout"];
 
-      if ($res["status"] != "200") {
-        $this->handleError($res["status"], $res["message"]);
-        $success = false;
-      }
-    } else {
-      // we have to read from the socket to avoid getting into
-      // states where the socket doesn't properly re-open.
-      // as long as we keep the recv buffer empty, php will
-      // properly reconnect
-      stream_set_timeout($socket, 0, 50000);
-      fread($socket, 2048);
-      stream_set_timeout($socket, 5);
+        try {
+            # Open our socket to the API Server.
+            # Since we're try catch'ing prevent PHP logs.
+            $socket = @pfsockopen($protocol . "://" . $host, $port, $errno,
+                $errstr, $timeout);
+
+            # If we couldn't open the socket, handle the error.
+            if (false === $socket) {
+                $this->handleError($errno, $errstr);
+                $this->socket_failed = true;
+                return false;
+            }
+
+            return $socket;
+
+        } catch (Exception $e) {
+            $this->handleError($e->getCode(), $e->getMessage());
+            $this->socket_failed = true;
+            return false;
+        }
     }
 
-    return $success;
-  }
+    /**
+     * Attempt to write the request to the socket, wait for response if debug
+     * mode is enabled
+     *
+     * @param resource $socket the handle for the socket
+     * @param string $req request body
+     * @param boolean $retry
+     *
+     * @return boolean $success
+     */
+    private function makeRequest($socket, $req, $retry = true)
+    {
+
+        $bytes_written = 0;
+        $bytes_total = strlen($req);
+        $closed = false;
+
+        # Write the request
+        while (!$closed && $bytes_written < $bytes_total) {
+            try {
+                # Since we're try catch'ing prevent PHP logs.
+                $written = @fwrite($socket, substr($req, $bytes_written));
+            } catch (Exception $e) {
+                $this->handleError($e->getCode(), $e->getMessage());
+                $closed = true;
+            }
+            if (!isset($written) || !$written) {
+                $closed = true;
+            } else {
+                $bytes_written += $written;
+            }
+        }
+
+        # If the socket has been closed, attempt to retry a single time.
+        if ($closed) {
+            fclose($socket);
+
+            if ($retry) {
+                $socket = $this->createSocket();
+                if ($socket) {
+                    return $this->makeRequest($socket, $req, false);
+                }
+            }
+            return false;
+        }
 
 
-  /**
-   * Create the body to send as the post request.
-   * @param  string $host
-   * @param  string $content
-   * @return string body
-   */
-  private function createBody($host, $content) {
+        $success = true;
 
-    $req = "";
-    $req.= "POST /v1/import HTTP/1.1\r\n";
-    $req.= "Host: " . $host . "\r\n";
-    $req.= "Content-Type: application/json\r\n";
-    $req.= "Authorization: Basic " . base64_encode($this->secret . ":") . "\r\n";
-    $req.= "Accept: application/json\r\n";
-    $req.= "Content-length: " . strlen($content) . "\r\n";
-    $req.= "\r\n";
-    $req.= $content;
+        if ($this->debug()) {
+            $res = $this->parseResponse(fread($socket, 2048));
 
-    return $req;
-  }
+            if ($res["status"] != "200") {
+                $this->handleError($res["status"], $res["message"]);
+                $success = false;
+            }
+        } else {
+            // we have to read from the socket to avoid getting into
+            // states where the socket doesn't properly re-open.
+            // as long as we keep the recv buffer empty, php will
+            // properly reconnect
+            stream_set_timeout($socket, 0, 50000);
+            fread($socket, 2048);
+            stream_set_timeout($socket, 5);
+        }
 
+        return $success;
+    }
 
-  /**
-   * Parse our response from the server, check header and body.
-   * @param  string $res
-   * @return array
-   *     string $status  HTTP code, e.g. "200"
-   *     string $message JSON response from the api
-   */
-  private function parseResponse($res) {
+    /**
+     * Create the body to send as the post request
+     *
+     * @param string $host
+     * @param string $content
+     *
+     * @return string body
+     */
+    private function createBody($host, $content)
+    {
 
-    $contents = explode("\n", $res);
+        $req = "";
+        $req .= "POST /v1/import HTTP/1.1\r\n";
+        $req .= "Host: " . $host . "\r\n";
+        $req .= "Content-Type: application/json\r\n";
+        $req .= "Authorization: Basic " . base64_encode($this->secret . ":") . "\r\n";
+        $req .= "Accept: application/json\r\n";
+        $req .= "Content-length: " . strlen($content) . "\r\n";
+        $req .= "\r\n";
+        $req .= $content;
 
-    # Response comes back as HTTP/1.1 200 OK
-    # Final line contains HTTP response.
-    $status = explode(" ", $contents[0], 3);
-    $result = $contents[count($contents) - 1];
+        return $req;
+    }
 
-    return array(
-      "status"  => isset($status[1]) ? $status[1] : null,
-      "message" => $result
-    );
-  }
+    /**
+     * Parse our response from the server, check header and body
+     *
+     * @param string $res
+     * 
+     * @return array
+     *     string $status  HTTP code, e.g. "200"
+     *     string $message JSON response from the api
+     */
+    private function parseResponse($res)
+    {
+
+        $contents = explode("\n", $res);
+
+        # Response comes back as HTTP/1.1 200 OK
+        # Final line contains HTTP response.
+        $status = explode(" ", $contents[0], 3);
+        $result = $contents[count($contents) - 1];
+
+        return array(
+            "status" => isset($status[1]) ? $status[1] : null,
+            "message" => $result
+        );
+    }
 }

--- a/lib/Segment/QueueConsumer.php
+++ b/lib/Segment/QueueConsumer.php
@@ -1,154 +1,195 @@
 <?php
-abstract class Segment_QueueConsumer extends Segment_Consumer {
 
-  protected $type = "QueueConsumer";
+abstract class Segment_QueueConsumer extends Segment_Consumer
+{
+    /**
+     * @var string
+     */
+    protected $type = "QueueConsumer";
 
-  protected $queue;
-  protected $max_queue_size = 1000;
-  protected $batch_size = 100;
+    /**
+     * @var array
+     */
+    protected $queue;
 
-  /**
-   * Store our secret and options as part of this consumer
-   * @param string $secret
-   * @param array  $options
-   */
-  public function __construct($secret, $options = array()) {
-    parent::__construct($secret, $options);
+    /**
+     * @var integer
+     */
+    protected $max_queue_size = 1000;
 
-    if (isset($options["max_queue_size"]))
-      $this->max_queue_size = $options["max_queue_size"];
+    /**
+     * @var integer
+     */
+    protected $batch_size = 100;
 
-    if (isset($options["batch_size"]))
-      $this->batch_size = $options["batch_size"];
+    /**
+     * Store our secret and options as part of this consumer
+     *
+     * @param string $secret
+     * @param array $options
+     */
+    public function __construct($secret, $options = array())
+    {
+        parent::__construct($secret, $options);
 
-    $this->queue = array();
-  }
+        if (isset($options["max_queue_size"])) {
+            $this->max_queue_size = $options["max_queue_size"];
+        }
 
-  public function __destruct() {
-    # Flush our queue on destruction
-    $this->flush();
-  }
+        if (isset($options["batch_size"])) {
+            $this->batch_size = $options["batch_size"];
+        }
 
-  /**
-   * Tracks a user action
-   *
-   * @param  array  $message
-   * @return boolean whether the track call succeeded
-   */
-  public function track(array $message) {
-    return $this->enqueue($message);
-  }
-
-  /**
-   * Tags traits about the user.
-   *
-   * @param  array  $message
-   * @return boolean whether the identify call succeeded
-   */
-  public function identify(array $message) {
-    return $this->enqueue($message);
-  }
-
-  /**
-   * Tags traits about the group.
-   *
-   * @param  array  $message
-   * @return boolean whether the group call succeeded
-   */
-  public function group(array $message) {
-    return $this->enqueue($message);
-  }
-
-  /**
-   * Tracks a page view.
-   *
-   * @param  array  $message
-   * @return boolean whether the page call succeeded
-   */
-  public function page(array $message) {
-    return $this->enqueue($message);
-  }
-
-  /**
-   * Tracks a screen view.
-   *
-   * @param  array  $message
-   * @return boolean whether the screen call succeeded
-   */
-  public function screen(array $message) {
-    return $this->enqueue($message);
-  }
-
-  /**
-   * Aliases from one user id to another
-   *
-   * @param  array $message
-   * @return boolean whether the alias call succeeded
-   */
-  public function alias(array $message) {
-    return $this->enqueue($message);
-  }
-
-  /**
-   * Adds an item to our queue.
-   * @param  mixed   $item
-   * @return boolean whether call has succeeded
-   */
-  protected function enqueue($item) {
-
-    $count = count($this->queue);
-
-    if ($count > $this->max_queue_size) {
-      return false;
+        $this->queue = array();
     }
 
-    $count = array_push($this->queue, $item);
-
-    if ($count >= $this->batch_size) {
-      return $this->flush(); // return ->flush() result: true on success
+    /**
+     * Do a final flush
+     */
+    public function __destruct()
+    {
+        # Flush our queue on destruction
+        $this->flush();
     }
 
-    return true;
-  }
-
-
-  /**
-   * Flushes our queue of messages by batching them to the server
-   */
-  public function flush() {
-
-    $count = count($this->queue);
-    $success = true;
-
-    while($count > 0 && $success) {
-
-      $batch = array_splice($this->queue, 0, min($this->batch_size, $count));
-      $success = $this->flushBatch($batch);
-
-      $count = count($this->queue);
+    /**
+     * Tracks a user action
+     *
+     * @param array $message
+     *
+     * @return boolean whether the track call succeeded
+     */
+    public function track(array $message)
+    {
+        return $this->enqueue($message);
     }
 
-    return $success;
-  }
+    /**
+     * Tags traits about the user
+     *
+     * @param array $message
+     *
+     * @return boolean whether the identify call succeeded
+     */
+    public function identify(array $message)
+    {
+        return $this->enqueue($message);
+    }
 
-  /**
-   * Given a batch of messages the method returns
-   * a valid payload.
-   * 
-   * @param {Array} batch
-   * @return {Array}
-   **/
-  protected function payload($batch){
-    return array(
-      "batch" => $batch,
-      "sentAt" => date("c"),
-    );
-  }
+    /**
+     * Tags traits about the group
+     *
+     * @param array $message
+     *
+     * @return boolean whether the group call succeeded
+     */
+    public function group(array $message)
+    {
+        return $this->enqueue($message);
+    }
 
-  /**
-   * Flushes a batch of messages.
-   * @param  [type] $batch [description]
-   * @return [type]        [description]
-   */
-  abstract function flushBatch($batch);
+    /**
+     * Tracks a page view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the page call succeeded
+     */
+    public function page(array $message)
+    {
+        return $this->enqueue($message);
+    }
+
+    /**
+     * Tracks a screen view
+     *
+     * @param array $message
+     *
+     * @return boolean whether the screen call succeeded
+     */
+    public function screen(array $message)
+    {
+        return $this->enqueue($message);
+    }
+
+    /**
+     * Aliases from one user id to another
+     *
+     * @param array $message
+     *
+     * @return boolean whether the alias call succeeded
+     */
+    public function alias(array $message)
+    {
+        return $this->enqueue($message);
+    }
+
+    /**
+     * Adds an item to our queue
+     *
+     * @param mixed $item
+     *
+     * @return boolean whether call has succeeded
+     */
+    protected function enqueue($item)
+    {
+
+        $count = count($this->queue);
+
+        if ($count > $this->max_queue_size) {
+            return false;
+        }
+
+        $count = array_push($this->queue, $item);
+
+        if ($count >= $this->batch_size) {
+            return $this->flush(); // return ->flush() result: true on success
+        }
+
+        return true;
+    }
+
+    /**
+     * Flushes our queue of messages by batching them to the server
+     */
+    public function flush()
+    {
+
+        $count = count($this->queue);
+        $success = true;
+
+        while ($count > 0 && $success) {
+
+            $batch = array_splice($this->queue, 0, min($this->batch_size, $count));
+            $success = $this->flushBatch($batch);
+
+            $count = count($this->queue);
+        }
+
+        return $success;
+    }
+
+    /**
+     * Given a batch of messages the method returns a valid payload
+     *
+     * @param array $batch
+     * 
+     * @return array
+     **/
+    protected function payload($batch)
+    {
+        return array(
+            "batch" => $batch,
+            "sentAt" => date("c"),
+        );
+    }
+
+    /**
+     * Flushes a batch of messages
+     *
+     * @param array $batch
+     *
+     * @return boolean
+     */
+    abstract function flushBatch($batch);
 }

--- a/lib/Segment/Version.php
+++ b/lib/Segment/Version.php
@@ -1,4 +1,3 @@
 <?php
 global $SEGMENT_VERSION;
 $SEGMENT_VERSION = "1.4.2";
-?>

--- a/send.php
+++ b/send.php
@@ -16,11 +16,17 @@ $args = parse($argv);
  * Make sure both are set
  */
 
-if (!isset($args["secret"])) die("--secret must be given");
-if (!isset($args["file"])) die("--file must be given");
+if (!isset($args["secret"])) {
+    die("--secret must be given");
+}
+if (!isset($args["file"])) {
+    die("--file must be given");
+}
 
 $file = $args["file"];
-if ($file[0] != '/') $file = __DIR__ . "/" . $file;
+if ($file[0] != '/') {
+    $file = __DIR__ . "/" . $file;
+}
 
 /**
  * Rename the file so we don't write the same calls
@@ -31,14 +37,14 @@ $dir = dirname($file);
 $old = $file;
 $file = $dir . '/analytics-' . rand() . '.log';
 
-if(!file_exists($old)) {
-  print("file: $old does not exist");
-  exit(0);
+if (!file_exists($old)) {
+    print("file: $old does not exist");
+    exit(0);
 }
 
 if (!rename($old, $file)) {
-  print("error renaming from $old to $file\n");
-  exit(1);
+    print("error renaming from $old to $file\n");
+    exit(1);
 }
 
 /**
@@ -53,11 +59,11 @@ $lines = explode("\n", $contents);
  */
 
 Segment::init($args["secret"], array(
-  "debug" => true,
-  "error_handler" => function($code, $msg){
-    print("$code: $msg\n");
-    exit(1);
-  }
+    "debug" => true,
+    "error_handler" => function ($code, $msg) {
+        print("$code: $msg\n");
+        exit(1);
+    }
 ));
 
 /**
@@ -67,16 +73,22 @@ Segment::init($args["secret"], array(
 $total = 0;
 $successful = 0;
 foreach ($lines as $line) {
-  if (!trim($line)) continue;
-  $payload = json_decode($line, true);
-  $dt = new DateTime($payload["timestamp"]);
-  $ts = floatval($dt->getTimestamp() . "." . $dt->format("u"));
-  $payload["timestamp"] = $ts;
-  $type = $payload["type"];
-  $ret = call_user_func_array(array("Segment", $type), array($payload));
-  if ($ret) $successful++;
-  $total++;
-  if ($total % 100 === 0) Segment::flush();
+    if (!trim($line)) {
+        continue;
+    }
+    $payload = json_decode($line, true);
+    $dt = new DateTime($payload["timestamp"]);
+    $ts = floatval($dt->getTimestamp() . "." . $dt->format("u"));
+    $payload["timestamp"] = $ts;
+    $type = $payload["type"];
+    $ret = call_user_func_array(array("Segment", $type), array($payload));
+    if ($ret) {
+        $successful++;
+    }
+    $total++;
+    if ($total % 100 === 0) {
+        Segment::flush();
+    }
 }
 
 Segment::flush();
@@ -93,14 +105,17 @@ exit(0);
  * Parse arguments
  */
 
-function parse($argv){
-  $ret = array();
+function parse($argv)
+{
+    $ret = array();
 
-  for ($i = 0; $i < count($argv); ++$i) {
-    $arg = $argv[$i];
-    if ('--' != substr($arg, 0, 2)) continue;
-    $ret[substr($arg, 2, strlen($arg))] = trim($argv[++$i]);
-  }
+    for ($i = 0; $i < count($argv); ++$i) {
+        $arg = $argv[$i];
+        if ('--' != substr($arg, 0, 2)) {
+            continue;
+        }
+        $ret[substr($arg, 2, strlen($arg))] = trim($argv[++$i]);
+    }
 
-  return $ret;
+    return $ret;
 }

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -2,189 +2,203 @@
 
 require_once(dirname(__FILE__) . "/../lib/Segment.php");
 
-class AnalyticsTest extends PHPUnit_Framework_TestCase {
+class AnalyticsTest extends PHPUnit_Framework_TestCase
+{
+    function setUp()
+    {
+        date_default_timezone_set("UTC");
+        Segment::init("oq0vdlg7yi", array("debug" => true));
+    }
 
-  function setUp() {
-    date_default_timezone_set("UTC");
-    Segment::init("oq0vdlg7yi", array("debug" => true));
-  }
+    function testTrack()
+    {
+        $this->assertTrue(Segment::track(array(
+            "userId" => "john",
+            "event" => "Module PHP Event"
+        )));
+    }
 
-  function testTrack() {
-    $this->assertTrue(Segment::track(array(
-      "userId" => "john",
-      "event" => "Module PHP Event"
-    )));
-  }
+    function testGroup()
+    {
+        $this->assertTrue(Segment::group(array(
+            "groupId" => "group-id",
+            "userId" => "user-id",
+            "traits" => array(
+                "plan" => "startup"
+            )
+        )));
+    }
 
-  function testGroup(){
-    $this->assertTrue(Segment::group(array(
-      "groupId" => "group-id",
-      "userId" => "user-id",
-      "traits" => array(
-        "plan" => "startup"
-      )
-    )));
-  }
+    function testMicrotime()
+    {
+        $this->assertTrue(Segment::page(array(
+            "anonymousId" => "anonymous-id",
+            "name" => "analytics-php-microtime",
+            "category" => "docs",
+            "timestamp" => microtime(true),
+            "properties" => array(
+                "path" => "/docs/libraries/php/",
+                "url" => "https://segment.io/docs/libraries/php/"
+            )
+        )));
+    }
 
-  function testMicrotime(){
-    $this->assertTrue(Segment::page(array(
-      "anonymousId" => "anonymous-id",
-      "name" => "analytics-php-microtime",
-      "category" => "docs",
-      "timestamp" => microtime(true),
-      "properties" => array(
-        "path" => "/docs/libraries/php/",
-        "url" => "https://segment.io/docs/libraries/php/"
-      )
-    )));    
-  }
+    function testPage()
+    {
+        $this->assertTrue(Segment::page(array(
+            "anonymousId" => "anonymous-id",
+            "name" => "analytics-php",
+            "category" => "docs",
+            "properties" => array(
+                "path" => "/docs/libraries/php/",
+                "url" => "https://segment.io/docs/libraries/php/"
+            )
+        )));
+    }
 
-  function testPage(){
-    $this->assertTrue(Segment::page(array(
-      "anonymousId" => "anonymous-id",
-      "name" => "analytics-php",
-      "category" => "docs",
-      "properties" => array(
-        "path" => "/docs/libraries/php/",
-        "url" => "https://segment.io/docs/libraries/php/"
-      )
-    )));
-  }
+    function testBasicPage()
+    {
+        $this->assertTrue(Segment::page(array(
+            "anonymousId" => "anonymous-id"
+        )));
+    }
 
-  function testBasicPage(){
-    $this->assertTrue(Segment::page(array(
-      "anonymousId" => "anonymous-id"
-    )));
-  }
+    function testScreen()
+    {
+        $this->assertTrue(Segment::screen(array(
+            "anonymousId" => "anonymous-id",
+            "name" => "2048",
+            "category" => "game built with php :)",
+            "properties" => array(
+                "points" => 300
+            )
+        )));
+    }
 
-  function testScreen(){
-    $this->assertTrue(Segment::screen(array(
-      "anonymousId" => "anonymous-id",
-      "name" => "2048",
-      "category" => "game built with php :)",
-      "properties" => array(
-        "points" => 300
-      )
-    )));
-  }
+    function testBasicScreen()
+    {
+        $this->assertTrue(Segment::screen(array(
+            "anonymousId" => "anonymous-id"
+        )));
+    }
 
-  function testBasicScreen(){
-    $this->assertTrue(Segment::screen(array(
-      "anonymousId" => "anonymous-id"
-    )));
-  }
+    function testIdentify()
+    {
+        $this->assertTrue(Segment::identify(array(
+            "userId" => "doe",
+            "traits" => array(
+                "loves_php" => false,
+                "birthday" => time()
+            )
+        )));
+    }
 
-  function testIdentify() {
-    $this->assertTrue(Segment::identify(array(
-      "userId" => "doe",
-      "traits" => array(
-        "loves_php" => false,
-        "birthday" => time()
-      )
-    )));
-  }
+    function testEmptyTraits()
+    {
+        $this->assertTrue(Segment::identify(array(
+            "userId" => "empty-traits"
+        )));
 
-  function testEmptyTraits() {
-    $this->assertTrue(Segment::identify(array(
-      "userId" => "empty-traits"
-    )));
+        $this->assertTrue(Segment::group(array(
+            "userId" => "empty-traits",
+            "groupId" => "empty-traits"
+        )));
+    }
 
-    $this->assertTrue(Segment::group(array(
-      "userId" => "empty-traits",
-      "groupId" => "empty-traits"
-    )));
-  }
+    function testEmptyArrayTraits()
+    {
+        $this->assertTrue(Segment::identify(array(
+            "userId" => "empty-traits",
+            "traits" => array()
+        )));
 
-  function testEmptyArrayTraits() {
-    $this->assertTrue(Segment::identify(array(
-      "userId" => "empty-traits",
-      "traits" => array()
-    )));
+        $this->assertTrue(Segment::group(array(
+            "userId" => "empty-traits",
+            "groupId" => "empty-traits",
+            "traits" => array()
+        )));
+    }
 
-    $this->assertTrue(Segment::group(array(
-      "userId" => "empty-traits",
-      "groupId" => "empty-traits",
-      "traits" => array()
-    )));
-  }
+    function testEmptyProperties()
+    {
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "empty-properties"
+        )));
 
-  function testEmptyProperties() {
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "empty-properties"
-    )));
+        $this->assertTrue(Segment::page(array(
+            "category" => "empty-properties",
+            "name" => "empty-properties",
+            "userId" => "user-id"
+        )));
+    }
 
-    $this->assertTrue(Segment::page(array(
-      "category" => "empty-properties",
-      "name" => "empty-properties",
-      "userId" => "user-id"
-    )));
-  }
+    function testEmptyArrayProperties()
+    {
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "empty-properties",
+            "properties" => array()
+        )));
 
-  function testEmptyArrayProperties(){
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "empty-properties",
-      "properties" => array()
-    )));
+        $this->assertTrue(Segment::page(array(
+            "category" => "empty-properties",
+            "name" => "empty-properties",
+            "userId" => "user-id",
+            "properties" => array()
+        )));
+    }
 
-    $this->assertTrue(Segment::page(array(
-      "category" => "empty-properties",
-      "name" => "empty-properties",
-      "userId" => "user-id",
-      "properties" => array()
-    )));
-  }
+    function testAlias()
+    {
+        $this->assertTrue(Segment::alias(array(
+            "previousId" => "previous-id",
+            "userId" => "user-id"
+        )));
+    }
 
-  function testAlias() {
-    $this->assertTrue(Segment::alias(array(
-      "previousId" => "previous-id",
-      "userId" => "user-id"
-    )));
-  }
+    function testTimestamps()
+    {
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "integer-timestamp",
+            "timestamp" => (int)mktime(0, 0, 0, date('n'), 1, date('Y'))
+        )));
 
-  function testTimestamps() {
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "integer-timestamp",
-      "timestamp" => (int) mktime(0, 0, 0, date('n'), 1, date('Y'))
-    )));
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "string-integer-timestamp",
+            "timestamp" => (string)mktime(0, 0, 0, date('n'), 1, date('Y'))
+        )));
 
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "string-integer-timestamp",
-      "timestamp" => (string) mktime(0, 0, 0, date('n'), 1, date('Y'))
-    )));
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "iso8630-timestamp",
+            "timestamp" => date(DATE_ATOM, mktime(0, 0, 0, date('n'), 1, date('Y')))
+        )));
 
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "iso8630-timestamp",
-      "timestamp" => date(DATE_ATOM, mktime(0, 0, 0, date('n'), 1, date('Y')))
-    )));
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "iso8601-timestamp",
+            "timestamp" => date(DATE_ATOM, mktime(0, 0, 0, date('n'), 1, date('Y')))
+        )));
 
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "iso8601-timestamp",
-      "timestamp" => date(DATE_ATOM, mktime(0, 0, 0, date('n'), 1, date('Y')))
-    )));
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "strtotime-timestamp",
+            "timestamp" => strtotime('1 week ago')
+        )));
 
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "strtotime-timestamp",
-      "timestamp" => strtotime('1 week ago')
-    )));
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "microtime-timestamp",
+            "timestamp" => microtime(true)
+        )));
 
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "microtime-timestamp",
-      "timestamp" => microtime(true)
-    )));
-
-    $this->assertTrue(Segment::track(array(
-      "userId" => "user-id",
-      "event" => "invalid-float-timestamp",
-      "timestamp" => ((string) mktime(0, 0, 0, date('n'), 1, date('Y'))) . '.'
-    )));
-  }
+        $this->assertTrue(Segment::track(array(
+            "userId" => "user-id",
+            "event" => "invalid-float-timestamp",
+            "timestamp" => ((string)mktime(0, 0, 0, date('n'), 1, date('Y'))) . '.'
+        )));
+    }
 }
-?>

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -2,121 +2,138 @@
 
 require_once(dirname(__FILE__) . "/../lib/Segment/Client.php");
 
-class ConsumerFileTest extends PHPUnit_Framework_TestCase {
+class ConsumerFileTest extends PHPUnit_Framework_TestCase
+{
+    private $client;
+    private $filename = "/tmp/analytics.log";
 
-  private $client;
-  private $filename = "/tmp/analytics.log";
+    function setUp()
+    {
+        date_default_timezone_set("UTC");
+        if (file_exists($this->filename())) {
+            unlink($this->filename());
+        }
 
-  function setUp() {
-    date_default_timezone_set("UTC");
-    if (file_exists($this->filename()))
-      unlink($this->filename());
+        $this->client = new Segment_Client("oq0vdlg7yi",
+            array(
+                "consumer" => "file",
+                "filename" => $this->filename
+            ));
 
-    $this->client = new Segment_Client("oq0vdlg7yi",
-                          array("consumer" => "file",
-                                "filename" => $this->filename));
-
-  }
-
-  function tearDown(){
-    if (file_exists($this->filename))
-      unlink($this->filename);
-  }
-
-  function testTrack() {
-    $this->assertTrue($this->client->track(array(
-      "userId" => "some-user",
-      "event" => "File PHP Event - Microtime",
-      "timestamp" => microtime(true),
-    )));
-    $this->checkWritten("track");
-  }
-
-  function testIdentify() {
-    $this->assertTrue($this->client->identify(array(
-      "userId" => "Calvin",
-      "traits" => array(
-        "loves_php" => false,
-        "type" => "analytics.log",
-        "birthday" => time()
-      )
-    )));
-    $this->checkWritten("identify");
-  }
-
-  function testGroup(){
-    $this->assertTrue($this->client->group(array(
-      "userId" => "user-id",
-      "groupId" => "group-id",
-      "traits" => array(
-        "type" => "consumer analytics.log test",
-      )
-    )));
-  }
-
-  function testPage(){
-    $this->assertTrue($this->client->page(array(
-      "userId" => "user-id",
-      "name" => "analytics-php",
-      "category" => "analytics.log",
-      "properties" => array(
-        "url" => "https://a.url/"
-      )
-    )));
-  }
-
-  function testScreen(){
-    $this->assertTrue($this->client->screen(array(
-      "userId" => "userId",
-      "name" => "grand theft auto",
-      "category" => "analytics.log",
-      "properties" => array()
-    )));
-  }
-
-  function testAlias () {
-    $this->assertTrue($this->client->alias(array(
-      "previousId" => "previous-id",
-      "userId" => "user-id"
-    )));
-    $this->checkWritten("alias");
-  }
-
-  function testSend(){
-    for ($i = 0; $i < 200; $i++) {
-      $this->client->track(array(
-        "userId" => "userId",
-        "event" => "event"
-      ));
     }
-    exec("php --define date.timezone=UTC send.php --secret oq0vdlg7yi --file /tmp/analytics.log", $output);
-    $this->assertEquals("sent 200 from 200 requests successfully", trim($output[0]));
-    $this->assertFalse(file_exists($this->filename()));
-  }
 
-  function testProductionProblems() {
-    # Open to a place where we should not have write access.
-    $client = new Segment_Client("oq0vdlg7yi",
-                          array("consumer" => "file",
-                                "filename" => "/dev/xxxxxxx" ));
+    function tearDown()
+    {
+        if (file_exists($this->filename)) {
+            unlink($this->filename);
+        }
+    }
 
-    $tracked = $client->track(array("userId" => "some-user", "event" => "my event"));
-    $this->assertFalse($tracked);
-  }
+    function testTrack()
+    {
+        $this->assertTrue($this->client->track(array(
+            "userId" => "some-user",
+            "event" => "File PHP Event - Microtime",
+            "timestamp" => microtime(true),
+        )));
+        $this->checkWritten("track");
+    }
 
-  function checkWritten($type) {
-    exec("wc -l " . $this->filename, $output);
-    $out = trim($output[0]);
-    $this->assertEquals($out, "1 " . $this->filename);
-    $str = file_get_contents($this->filename);
-    $json = json_decode(trim($str));
-    $this->assertEquals($type, $json->type);
-    unlink($this->filename);
-  }
+    function testIdentify()
+    {
+        $this->assertTrue($this->client->identify(array(
+            "userId" => "Calvin",
+            "traits" => array(
+                "loves_php" => false,
+                "type" => "analytics.log",
+                "birthday" => time()
+            )
+        )));
+        $this->checkWritten("identify");
+    }
 
-  function filename(){
-    return '/tmp/analytics.log';
-  }
+    function testGroup()
+    {
+        $this->assertTrue($this->client->group(array(
+            "userId" => "user-id",
+            "groupId" => "group-id",
+            "traits" => array(
+                "type" => "consumer analytics.log test",
+            )
+        )));
+    }
+
+    function testPage()
+    {
+        $this->assertTrue($this->client->page(array(
+            "userId" => "user-id",
+            "name" => "analytics-php",
+            "category" => "analytics.log",
+            "properties" => array(
+                "url" => "https://a.url/"
+            )
+        )));
+    }
+
+    function testScreen()
+    {
+        $this->assertTrue($this->client->screen(array(
+            "userId" => "userId",
+            "name" => "grand theft auto",
+            "category" => "analytics.log",
+            "properties" => array()
+        )));
+    }
+
+    function testAlias()
+    {
+        $this->assertTrue($this->client->alias(array(
+            "previousId" => "previous-id",
+            "userId" => "user-id"
+        )));
+        $this->checkWritten("alias");
+    }
+
+    function testSend()
+    {
+        for ($i = 0; $i < 200; $i++) {
+            $this->client->track(array(
+                "userId" => "userId",
+                "event" => "event"
+            ));
+        }
+        exec("php --define date.timezone=UTC send.php --secret oq0vdlg7yi --file /tmp/analytics.log", $output);
+        $this->assertEquals("sent 200 from 200 requests successfully", trim($output[0]));
+        $this->assertFalse(file_exists($this->filename()));
+    }
+
+    function testProductionProblems()
+    {
+        # Open to a place where we should not have write access.
+        $client = new Segment_Client("oq0vdlg7yi",
+            array(
+                "consumer" => "file",
+                "filename" => "/dev/xxxxxxx"
+            ));
+
+        $tracked = $client->track(array("userId" => "some-user", "event" => "my event"));
+        $this->assertFalse($tracked);
+    }
+
+    function checkWritten($type)
+    {
+        exec("wc -l " . $this->filename, $output);
+        $out = trim($output[0]);
+        $this->assertEquals($out, "1 " . $this->filename);
+        $str = file_get_contents($this->filename);
+        $json = json_decode(trim($str));
+        $this->assertEquals($type, $json->type);
+        unlink($this->filename);
+    }
+
+    function filename()
+    {
+        return '/tmp/analytics.log';
+    }
 
 }
-?>

--- a/test/ConsumerForkCurlTest.php
+++ b/test/ConsumerForkCurlTest.php
@@ -2,71 +2,79 @@
 
 require_once(dirname(__FILE__) . "/../lib/Segment/Client.php");
 
-class ConsumerForkCurlTest extends PHPUnit_Framework_TestCase {
+class ConsumerForkCurlTest extends PHPUnit_Framework_TestCase
+{
+    private $client;
 
-  private $client;
+    function setUp()
+    {
+        date_default_timezone_set("UTC");
+        $this->client = new Segment_Client("oq0vdlg7yi",
+            array(
+                "consumer" => "fork_curl",
+                "debug" => true
+            ));
+    }
 
-  function setUp() {
-    date_default_timezone_set("UTC");
-    $this->client = new Segment_Client("oq0vdlg7yi",
-                          array("consumer" => "fork_curl",
-                                "debug"    => true));
-  }
+    function testTrack()
+    {
+        $this->assertTrue($this->client->track(array(
+            "userId" => "some-user",
+            "event" => "PHP Fork Curl'd\" Event"
+        )));
+    }
 
-  function testTrack() {
-    $this->assertTrue($this->client->track(array(
-      "userId" => "some-user",
-      "event" => "PHP Fork Curl'd\" Event"
-    )));
-  }
+    function testIdentify()
+    {
+        $this->assertTrue($this->client->identify(array(
+            "userId" => "user-id",
+            "traits" => array(
+                "loves_php" => false,
+                "type" => "consumer fork-curl test",
+                "birthday" => time()
+            )
+        )));
+    }
 
-  function testIdentify() {
-    $this->assertTrue($this->client->identify(array(
-      "userId" => "user-id",
-      "traits"  => array(
-        "loves_php" => false,
-        "type" => "consumer fork-curl test",
-        "birthday" => time()
-      )
-    )));
-  }
+    function testGroup()
+    {
+        $this->assertTrue($this->client->group(array(
+            "userId" => "user-id",
+            "groupId" => "group-id",
+            "traits" => array(
+                "type" => "consumer fork-curl test"
+            )
+        )));
+    }
 
-  function testGroup(){
-    $this->assertTrue($this->client->group(array(
-      "userId" => "user-id",
-      "groupId" => "group-id",
-      "traits" => array(
-        "type" => "consumer fork-curl test"
-      )
-    )));
-  }
+    function testPage()
+    {
+        $this->assertTrue($this->client->page(array(
+            "userId" => "userId",
+            "name" => "analytics-php",
+            "category" => "fork-curl",
+            "properties" => array(
+                "url" => "https://a.url/"
+            )
+        )));
+    }
 
-  function testPage(){
-    $this->assertTrue($this->client->page(array(
-      "userId" => "userId",
-      "name" => "analytics-php",
-      "category" => "fork-curl",
-      "properties" => array(
-        "url" => "https://a.url/"
-      )
-    )));
-  }
-
-  function testScreen(){
-    $this->assertTrue($this->client->page(array(
-      "anonymousId" => "anonymous-id",
-      "name" => "grand theft auto",
-      "category" => "fork-curl",
-      "properties" => array()
-    )));
-  }
+    function testScreen()
+    {
+        $this->assertTrue($this->client->page(array(
+            "anonymousId" => "anonymous-id",
+            "name" => "grand theft auto",
+            "category" => "fork-curl",
+            "properties" => array()
+        )));
+    }
 
 
-  function testAlias() {
-    $this->assertTrue($this->client->alias(array(
-      "previousId" => "previous-id",
-      "userId" => "user-id"
-    )));
-  }
+    function testAlias()
+    {
+        $this->assertTrue($this->client->alias(array(
+            "previousId" => "previous-id",
+            "userId" => "user-id"
+        )));
+    }
 }
-?>

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -2,72 +2,79 @@
 
 require_once(dirname(__FILE__) . "/../lib/Segment/Client.php");
 
-class ConsumerLibCurlTest extends PHPUnit_Framework_TestCase {
+class ConsumerLibCurlTest extends PHPUnit_Framework_TestCase
+{
+    private $client;
 
-  private $client;
+    function setUp()
+    {
+        date_default_timezone_set("UTC");
+        $this->client = new Segment_Client("oq0vdlg7yi",
+            array(
+                "consumer" => "lib_curl",
+                "debug" => true
+            ));
+    }
 
-  function setUp() {
-    date_default_timezone_set("UTC");
-    $this->client = new Segment_Client("oq0vdlg7yi",
-                          array("consumer" => "lib_curl",
-                                "debug"    => true));
-  }
+    function testTrack()
+    {
+        $this->assertTrue($this->client->track(array(
+            "userId" => "lib-curl-track",
+            "event" => "PHP Lib Curl'd\" Event"
+        )));
+    }
 
-  function testTrack() {
-      $this->assertTrue($this->client->track(array(
-        "userId" => "lib-curl-track",
-        "event" => "PHP Lib Curl'd\" Event"
-      )));
-  }
+    function testIdentify()
+    {
+        $this->assertTrue($this->client->identify(array(
+            "userId" => "lib-curl-identify",
+            "traits" => array(
+                "loves_php" => false,
+                "type" => "consumer lib-curl test",
+                "birthday" => time()
+            )
+        )));
+    }
 
-  function testIdentify() {
-    $this->assertTrue($this->client->identify(array(
-      "userId" => "lib-curl-identify",
-      "traits"  => array(
-        "loves_php" => false,
-        "type" => "consumer lib-curl test",
-        "birthday" => time()
-      )
-    )));
-  }
+    function testGroup()
+    {
+        $this->assertTrue($this->client->group(array(
+            "userId" => "lib-curl-group",
+            "groupId" => "group-id",
+            "traits" => array(
+                "type" => "consumer lib-curl test"
+            )
+        )));
+    }
 
-  function testGroup(){
-    $this->assertTrue($this->client->group(array(
-      "userId" => "lib-curl-group",
-      "groupId" => "group-id",
-      "traits" => array(
-        "type" => "consumer lib-curl test"
-      )
-    )));
-  }
+    function testPage()
+    {
+        $this->assertTrue($this->client->page(array(
+            "userId" => "lib-curl-page",
+            "name" => "analytics-php",
+            "category" => "fork-curl",
+            "properties" => array(
+                "url" => "https://a.url/"
+            )
+        )));
+    }
 
-  function testPage(){
-    $this->assertTrue($this->client->page(array(
-      "userId" => "lib-curl-page",
-      "name" => "analytics-php",
-      "category" => "fork-curl",
-      "properties" => array(
-        "url" => "https://a.url/"
-      )
-    )));
-  }
-
-  function testScreen(){
-    $this->assertTrue($this->client->page(array(
-      "anonymousId" => "lib-curl-screen",
-      "name" => "grand theft auto",
-      "category" => "fork-curl",
-      "properties" => array()
-    )));
-  }
+    function testScreen()
+    {
+        $this->assertTrue($this->client->page(array(
+            "anonymousId" => "lib-curl-screen",
+            "name" => "grand theft auto",
+            "category" => "fork-curl",
+            "properties" => array()
+        )));
+    }
 
 
-  function testAlias() {
-    $this->assertTrue($this->client->alias(array(
-      "previousId" => "lib-curl-alias",
-      "userId" => "user-id"
-    )));
-  }
+    function testAlias()
+    {
+        $this->assertTrue($this->client->alias(array(
+            "previousId" => "lib-curl-alias",
+            "userId" => "user-id"
+        )));
+    }
 }
-
-?>

--- a/test/ConsumerSocketTest.php
+++ b/test/ConsumerSocketTest.php
@@ -2,153 +2,170 @@
 
 require_once(dirname(__FILE__) . "/../lib/Segment/Client.php");
 
-class ConsumerSocketTest extends PHPUnit_Framework_TestCase {
+class ConsumerSocketTest extends PHPUnit_Framework_TestCase
+{
+    private $client;
 
-  private $client;
-
-  function setUp() {
-    date_default_timezone_set("UTC");
-    $this->client = new Segment_Client("oq0vdlg7yi",
-                                          array("consumer" => "socket"));
-  }
-
-  function testTrack() {
-    $this->assertTrue($this->client->track(array(
-      "userId" => "some-user",
-      "event" => "Socket PHP Event"
-    )));
-  }
-
-  function testIdentify() {
-    $this->assertTrue($this->client->identify(array(
-      "userId" => "Calvin",
-      "traits" => array(
-        "loves_php" => false,
-        "birthday" => time()
-      )
-    )));
-  }
-
-  function testGroup(){
-    $this->assertTrue($this->client->group(array(
-      "userId" => "user-id",
-      "groupId" => "group-id",
-      "traits" => array(
-        "type" => "consumer socket test"
-      )
-    )));
-  }
-
-  function testPage(){
-    $this->assertTrue($this->client->page(array(
-      "userId" => "user-id",
-      "name" => "analytics-php",
-      "category" => "socket",
-      "properties" => array(
-        "url" => "https://a.url/"
-      )
-    )));
-  }
-
-  function testScreen(){
-    $this->assertTrue($this->client->screen(array(
-      "anonymousId" => "anonymousId",
-      "name" => "grand theft auto",
-      "category" => "socket",
-      "properties" => array()
-    )));
-  }
-
-  function testAlias() {
-    $this->assertTrue($this->client->alias(array(
-      "previousId" => "some-socket",
-      "userId" => "new-socket"
-    )));
-  }
-
-  function testShortTimeout() {
-    $client = new Segment_Client("oq0vdlg7yi",
-                                   array( "timeout"  => 0.01,
-                                          "consumer" => "socket" ));
-
-    $this->assertTrue($client->track(array(
-      "userId" => "some-user",
-      "event" => "Socket PHP Event"
-    )));
-
-    $this->assertTrue($client->identify(array(
-      "userId" => "some-user",
-      "traits" => array()
-    )));
-
-    $client->__destruct();
-  }
-
-  function testProductionProblems() {
-    $client = new Segment_Client("x", array(
-        "consumer"      => "socket",
-        "error_handler" => function () { throw new Exception("Was called"); }));
-
-    # Shouldn't error out without debug on.
-    $client->track(array("user_id" => "some-user", "event" => "Production Problems"));
-    $client->__destruct();
-  }
-
-  function testDebugProblems() {
-
-    $options = array(
-      "debug"         => true,
-      "consumer"      => "socket",
-      "error_handler" => function ($errno, $errmsg) {
-                            if ($errno != 400)
-                              throw new Exception("Response is not 400"); }
-    );
-
-    $client = new Segment_Client("x", $options);
-
-    # Should error out with debug on.
-    $client->track(array("user_id" => "some-user", "event" => "Socket PHP Event"));
-    $client->__destruct();
-  }
-
-
-  function testLargeMessage () {
-    $options = array(
-      "debug"    => true,
-      "consumer" => "socket"
-    );
-
-    $client = new Segment_Client("testsecret", $options);
-
-    $big_property = "";
-
-    for ($i = 0; $i < 10000; $i++) {
-      $big_property .= "a";
+    function setUp()
+    {
+        date_default_timezone_set("UTC");
+        $this->client = new Segment_Client("oq0vdlg7yi",
+            array("consumer" => "socket"));
     }
 
-    $this->assertTrue($client->track(array(
-      "userId" => "some-user",
-      "event" => "Super Large PHP Event",
-      "properties" => array("big_property" => $big_property)
-    )));
+    function testTrack()
+    {
+        $this->assertTrue($this->client->track(array(
+            "userId" => "some-user",
+            "event" => "Socket PHP Event"
+        )));
+    }
 
-    $client->__destruct();
-  }
+    function testIdentify()
+    {
+        $this->assertTrue($this->client->identify(array(
+            "userId" => "Calvin",
+            "traits" => array(
+                "loves_php" => false,
+                "birthday" => time()
+            )
+        )));
+    }
 
-  /**
-   * @expectedException \RuntimeException
-   */
-  function testConnectionError() {
-    $client = new Segment_Client("x", array(
-      "consumer"      => "socket",
-      "host"          => "api.segment.ioooooo",
-      "error_handler" => function ($errno, $errmsg) {
-        throw new \RuntimeException($errmsg, $errno);
-      },
-    ));
+    function testGroup()
+    {
+        $this->assertTrue($this->client->group(array(
+            "userId" => "user-id",
+            "groupId" => "group-id",
+            "traits" => array(
+                "type" => "consumer socket test"
+            )
+        )));
+    }
 
-    $client->track(array("user_id" => "some-user", "event" => "Event"));
-    $client->__destruct();
-  }
+    function testPage()
+    {
+        $this->assertTrue($this->client->page(array(
+            "userId" => "user-id",
+            "name" => "analytics-php",
+            "category" => "socket",
+            "properties" => array(
+                "url" => "https://a.url/"
+            )
+        )));
+    }
+
+    function testScreen()
+    {
+        $this->assertTrue($this->client->screen(array(
+            "anonymousId" => "anonymousId",
+            "name" => "grand theft auto",
+            "category" => "socket",
+            "properties" => array()
+        )));
+    }
+
+    function testAlias()
+    {
+        $this->assertTrue($this->client->alias(array(
+            "previousId" => "some-socket",
+            "userId" => "new-socket"
+        )));
+    }
+
+    function testShortTimeout()
+    {
+        $client = new Segment_Client("oq0vdlg7yi",
+            array(
+                "timeout" => 0.01,
+                "consumer" => "socket"
+            ));
+
+        $this->assertTrue($client->track(array(
+            "userId" => "some-user",
+            "event" => "Socket PHP Event"
+        )));
+
+        $this->assertTrue($client->identify(array(
+            "userId" => "some-user",
+            "traits" => array()
+        )));
+
+        $client->__destruct();
+    }
+
+    function testProductionProblems()
+    {
+        $client = new Segment_Client("x", array(
+            "consumer" => "socket",
+            "error_handler" => function () {
+                throw new Exception("Was called");
+            }
+        ));
+
+        # Shouldn't error out without debug on.
+        $client->track(array("user_id" => "some-user", "event" => "Production Problems"));
+        $client->__destruct();
+    }
+
+    function testDebugProblems()
+    {
+
+        $options = array(
+            "debug" => true,
+            "consumer" => "socket",
+            "error_handler" => function ($errno, $errmsg) {
+                if ($errno != 400) {
+                    throw new Exception("Response is not 400");
+                }
+            }
+        );
+
+        $client = new Segment_Client("x", $options);
+
+        # Should error out with debug on.
+        $client->track(array("user_id" => "some-user", "event" => "Socket PHP Event"));
+        $client->__destruct();
+    }
+
+    function testLargeMessage()
+    {
+        $options = array(
+            "debug" => true,
+            "consumer" => "socket"
+        );
+
+        $client = new Segment_Client("testsecret", $options);
+
+        $big_property = "";
+
+        for ($i = 0; $i < 10000; $i++) {
+            $big_property .= "a";
+        }
+
+        $this->assertTrue($client->track(array(
+            "userId" => "some-user",
+            "event" => "Super Large PHP Event",
+            "properties" => array("big_property" => $big_property)
+        )));
+
+        $client->__destruct();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    function testConnectionError()
+    {
+        $client = new Segment_Client("x", array(
+            "consumer" => "socket",
+            "host" => "api.segment.ioooooo",
+            "error_handler" => function ($errno, $errmsg) {
+                throw new \RuntimeException($errmsg, $errno);
+            },
+        ));
+
+        $client->track(array("user_id" => "some-user", "event" => "Event"));
+        $client->__destruct();
+    }
 }
-?>


### PR DESCRIPTION
# Description

This PR aims to add support for PSR-1 and PSR-2. No logic changes have been added. It also fixes some incorrect data types reported in docblocks. It implements a consistent formatting for docblocks:
- A new line must exist before any `@param` line
- A new line must exist before the `@return` line
- A new line must exist before any `@throws` line
- A single space between types and names for `@param`s
- Final periods have been removed from sentences (trying to be consistent across the board)
- Integer data types are written as `integer` (options are `int` and `integer`)
- Boolean data types are written as `boolean` (options are `bool` and `boolean`)

Let me know what you guys think!

ps: I just looked at this [comment](https://github.com/segmentio/analytics-php/pull/78#issuecomment-251824798), hopefully this PR can make its way through. I feel that PSR-1 and PSR-2 can help to make this package complaint with php standards. I am open to adjust some of the dockblocks as long as things are consistent across all the files.
