### PR TITLE
Only create single Segment_client

### DIFF
--- a/lib/Segment.php
+++ b/lib/Segment.php
@@ -18,6 +18,7 @@ class Segment {
    */
   public static function init($secret, $options = array()) {
     self::assert($secret, "Segment::init() requires secret");
+    if (null != self::$client) return;
     self::$client = new Segment_Client($secret, $options);
   }
 


### PR DESCRIPTION
When ::init() is called multiple times, a new Segment_Client gets created each time. If we've already ::init'ed once, no need to create new SegmentClient