### PR TITLE
Libcurl error handling

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -18,7 +18,8 @@ class Segment_Client {
    *
    * @param string $secret
    * @param array  $options array of consumer options [optional]
-   * @param string Consumer constructor to use, socket by default.
+   * @param string Consumer constructor to use, libcurl by default.
+   *
    */
   public function __construct($secret, $options = array()) {
 
@@ -29,12 +30,14 @@ class Segment_Client {
       "lib_curl"   => "Segment_Consumer_LibCurl"
     );
 
-    # Use our socket consumer by default
+    # Use our socket libcurl by default
     $consumer_type = isset($options["consumer"]) ? $options["consumer"] :
                                                    "lib_curl";
+
     $Consumer = $consumers[$consumer_type];
 
     $this->consumer = new $Consumer($secret, $options);
+
   }
 
   public function __destruct() {


### PR DESCRIPTION
@calvinfo @jpcarriero PR to automatically retry events once for our default consumer (libcurl) if we don't receive a 200 response from the Segment API. The failing test returns the error "No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself" - any ideas on how to force another build to see if this error goes away?