### PR TITLE
Use require_once() instead of require().

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require(__DIR__ . '/../lib/Segment.php');
+require_once(__DIR__ . '/../lib/Segment.php');
 
 if (in_array('--help', $argv)) {
   print(usage());

--- a/lib/Segment.php
+++ b/lib/Segment.php
@@ -4,7 +4,7 @@ if (!function_exists('json_encode')) {
     throw new Exception('Segment needs the JSON PHP extension.');
 }
 
-require(dirname(__FILE__) . '/Segment/Client.php');
+require_once(dirname(__FILE__) . '/Segment/Client.php');
 
 
 class Segment {

--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -1,12 +1,12 @@
 <?php
 
-require(__DIR__ . '/Consumer.php');
-require(__DIR__ . '/QueueConsumer.php');
-require(__DIR__ . '/Consumer/File.php');
-require(__DIR__ . '/Consumer/ForkCurl.php');
-require(__DIR__ . '/Consumer/LibCurl.php');
-require(__DIR__ . '/Consumer/Socket.php');
-require(__DIR__ . '/Version.php');
+require_once(__DIR__ . '/Consumer.php');
+require_once(__DIR__ . '/QueueConsumer.php');
+require_once(__DIR__ . '/Consumer/File.php');
+require_once(__DIR__ . '/Consumer/ForkCurl.php');
+require_once(__DIR__ . '/Consumer/LibCurl.php');
+require_once(__DIR__ . '/Consumer/Socket.php');
+require_once(__DIR__ . '/Version.php');
 
 class Segment_Client {
 

--- a/send.php
+++ b/send.php
@@ -4,7 +4,7 @@
  * require client
  */
 
-require(__DIR__ . "/lib/Segment.php");
+require_once(__DIR__ . "/lib/Segment.php");
 
 /**
  * Args


### PR DESCRIPTION
Fixes issue where separate plugins in systems such as Moodle break because of class redeclaration when using separate internal versions of Segment.io.

@calvinfo 