### PR TITLE
Update logic to set context object, tests

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -166,7 +166,7 @@ class Segment_Client {
   }
 
   /**
-   * Add common fields to the gvien `message`
+   * Add common fields to the given `message`
    *
    * @param array $msg
    * @param string $def
@@ -177,8 +177,10 @@ class Segment_Client {
     if ($def && !isset($msg[$def])) $msg[$def] = array();
     if ($def && empty($msg[$def])) $msg[$def] = (object)$msg[$def];
 
-    if (!isset($msg["context"])) {
-      $msg["context"] = array();
+    if (!isset($msg["context"]["library"])) {
+      // must set $msg["context"]["library"] to empty array
+      // otherwise library will return "undefined index" error
+      $msg["context"]["library"] = array();
       $msg["context"] = array_merge($msg["context"], $this->getContext());
     }
 

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -6,7 +6,7 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
 
   function setUp() {
     date_default_timezone_set("UTC");
-    Segment::init("oq0vdlg7yi", array("debug" => true));
+    Segment::init("4txshy8l73", array("debug" => true));
   }
 
   function testTrack() {
@@ -36,7 +36,7 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
         "path" => "/docs/libraries/php/",
         "url" => "https://segment.io/docs/libraries/php/"
       )
-    )));    
+    )));
   }
 
   function testPage(){
@@ -140,6 +140,18 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(Segment::alias(array(
       "previousId" => "previous-id",
       "userId" => "user-id"
+    )));
+  }
+
+  function testSetContext(){
+    $this->assertTrue(Segment::track(array(
+      "anonymousId" => "set context",
+      "event" => "set context",
+      "context" => array(
+          "Google Analytics" => array(
+              "clientId" => "123"
+          )
+      )
     )));
   }
 

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -12,7 +12,7 @@ class ConsumerFileTest extends PHPUnit_Framework_TestCase {
     if (file_exists($this->filename()))
       unlink($this->filename());
 
-    $this->client = new Segment_Client("oq0vdlg7yi",
+    $this->client = new Segment_Client("4txshy8l73",
                           array("consumer" => "file",
                                 "filename" => $this->filename));
 
@@ -89,14 +89,14 @@ class ConsumerFileTest extends PHPUnit_Framework_TestCase {
         "event" => "event"
       ));
     }
-    exec("php --define date.timezone=UTC send.php --secret oq0vdlg7yi --file /tmp/analytics.log", $output);
+    exec("php --define date.timezone=UTC send.php --secret 4txshy8l73 --file /tmp/analytics.log", $output);
     $this->assertEquals("sent 200 from 200 requests successfully", trim($output[0]));
     $this->assertFalse(file_exists($this->filename()));
   }
 
   function testProductionProblems() {
     # Open to a place where we should not have write access.
-    $client = new Segment_Client("oq0vdlg7yi",
+    $client = new Segment_Client("4txshy8l73",
                           array("consumer" => "file",
                                 "filename" => "/dev/xxxxxxx" ));
 

--- a/test/ConsumerForkCurlTest.php
+++ b/test/ConsumerForkCurlTest.php
@@ -8,7 +8,7 @@ class ConsumerForkCurlTest extends PHPUnit_Framework_TestCase {
 
   function setUp() {
     date_default_timezone_set("UTC");
-    $this->client = new Segment_Client("oq0vdlg7yi",
+    $this->client = new Segment_Client("4txshy8l73",
                           array("consumer" => "fork_curl",
                                 "debug"    => true));
   }
@@ -60,7 +60,6 @@ class ConsumerForkCurlTest extends PHPUnit_Framework_TestCase {
       "properties" => array()
     )));
   }
-
 
   function testAlias() {
     $this->assertTrue($this->client->alias(array(

--- a/test/ConsumerLibCurlTest.php
+++ b/test/ConsumerLibCurlTest.php
@@ -8,7 +8,7 @@ class ConsumerLibCurlTest extends PHPUnit_Framework_TestCase {
 
   function setUp() {
     date_default_timezone_set("UTC");
-    $this->client = new Segment_Client("oq0vdlg7yi",
+    $this->client = new Segment_Client("4txshy8l73",
                           array("consumer" => "lib_curl",
                                 "debug"    => true));
   }
@@ -45,7 +45,7 @@ class ConsumerLibCurlTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue($this->client->page(array(
       "userId" => "lib-curl-page",
       "name" => "analytics-php",
-      "category" => "fork-curl",
+      "category" => "lib-curl",
       "properties" => array(
         "url" => "https://a.url/"
       )
@@ -56,11 +56,10 @@ class ConsumerLibCurlTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue($this->client->page(array(
       "anonymousId" => "lib-curl-screen",
       "name" => "grand theft auto",
-      "category" => "fork-curl",
+      "category" => "lib-curl",
       "properties" => array()
     )));
   }
-
 
   function testAlias() {
     $this->assertTrue($this->client->alias(array(

--- a/test/ConsumerSocketTest.php
+++ b/test/ConsumerSocketTest.php
@@ -8,7 +8,7 @@ class ConsumerSocketTest extends PHPUnit_Framework_TestCase {
 
   function setUp() {
     date_default_timezone_set("UTC");
-    $this->client = new Segment_Client("oq0vdlg7yi",
+    $this->client = new Segment_Client("4txshy8l73",
                                           array("consumer" => "socket"));
   }
 
@@ -67,7 +67,7 @@ class ConsumerSocketTest extends PHPUnit_Framework_TestCase {
   }
 
   function testShortTimeout() {
-    $client = new Segment_Client("oq0vdlg7yi",
+    $client = new Segment_Client("4txshy8l73",
                                    array( "timeout"  => 0.01,
                                           "consumer" => "socket" ));
 


### PR DESCRIPTION
@calvinfo This PR fixes a bug introduced in release 1.5.0 resulting in no call to the getContext() method if an event's context object is pre-set (e.g. if a user manually adds a Google or Marketo cookie to the object). At least one customer noted the side effect to Success - the library and version aren't set in the event's raw payload in the Segment debugger.

The new logic checks whether "library" specifically has been set. If not, the PHP library makes a call to getContext() and merges the returned array with any pre-existing context array.

Let me know if the new logic to prevent this looks sound here!