### PR TITLE
Add option to check the max request size of requests

### DIFF
--- a/lib/Segment/Consumer/ForkCurl.php
+++ b/lib/Segment/Consumer/ForkCurl.php
@@ -26,13 +26,10 @@ class Segment_Consumer_ForkCurl extends Segment_QueueConsumer {
   /**
    * Make an async request to our API. Fork a curl process, immediately send
    * to the API. If debug is enabled, we wait for the response.
-   * @param  array   $messages array of all the messages to send
+   * @param  string   $payload JSON object of all the messages to send
    * @return boolean whether the request succeeded
    */
-  public function flushBatch($messages) {
-
-    $body = $this->payload($messages);
-    $payload = json_encode($body);
+  public function flushBatch($payload) {
 
     # Escape for shell usage.
     $payload = escapeshellarg($payload);

--- a/lib/Segment/Consumer/LibCurl.php
+++ b/lib/Segment/Consumer/LibCurl.php
@@ -25,13 +25,11 @@ class Segment_Consumer_LibCurl extends Segment_QueueConsumer {
    * Make a sync request to our API. If debug is
    * enabled, we wait for the response
    * and retry once to diminish impact on performance.
-   * @param  array   $messages array of all the messages to send
+   * @param  string   $payload JSON object of all the messages to send
    * @return boolean whether the request succeeded
    */
-  public function flushBatch($messages) {
+  public function flushBatch($payload) {
 
-    $body = $this->payload($messages);
-    $payload = json_encode($body);
     $secret = $this->secret;
 
     $protocol = $this->ssl() ? "https://" : "http://";

--- a/lib/Segment/Consumer/Socket.php
+++ b/lib/Segment/Consumer/Socket.php
@@ -30,14 +30,11 @@ class Segment_Consumer_Socket extends Segment_QueueConsumer {
   }
 
 
-  public function flushBatch($batch) {
+  public function flushBatch($payload) {
     $socket = $this->createSocket();
 
     if (!$socket)
       return;
-
-    $payload = $this->payload($batch);
-    $payload = json_encode($payload);
 
     $body = $this->createBody($this->options["host"], $payload);
     return $this->makeRequest($socket, $body);

--- a/lib/Segment/QueueConsumer.php
+++ b/lib/Segment/QueueConsumer.php
@@ -8,6 +8,23 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
   protected $batch_size = 100;
 
   /**
+   * There is a maximum of 500kb per batch request and 32kb per call.
+   *
+   * The API will return a 400 response for batch sizes that are over 500kb but
+   * will still return 200 if the individual calls are over 32kb. Unfortunately,
+   * those calls will silently fail.
+   *
+   * This option allows PHP to raise an error when request sizes are over the
+   * API set limit to avoid silently lost data.
+   *
+   * @see https://segment.com/docs/sources/server/http/#max-request-size
+   */
+  protected $check_max_request_size = true;
+
+  const MAX_REQUEST_CALL_SIZE_LIMIT = 32000;
+  const MAX_REQUEST_BATCH_SIZE_LIMIT = 500000;
+
+  /**
    * Store our secret and options as part of this consumer
    * @param string $secret
    * @param array  $options
@@ -20,6 +37,9 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
 
     if (isset($options["batch_size"]))
       $this->batch_size = $options["batch_size"];
+
+    if (isset($options["check_max_request_size"]))
+      $this->check_max_request_size = $options["check_max_request_size"];
 
     $this->queue = array();
   }
@@ -89,17 +109,35 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
     return $this->enqueue($message);
   }
 
-  /**
-   * Adds an item to our queue.
-   * @param  mixed   $item
-   * @return boolean whether call has succeeded
-   */
+    /**
+     * Adds an item to our queue.
+     * @param  mixed $item
+     * @return bool whether call has succeeded
+     */
   protected function enqueue($item) {
 
     $count = count($this->queue);
 
     if ($count > $this->max_queue_size) {
       return false;
+    }
+
+    /**
+     * There is a maximum of 500kb per batch request and 32kb per call.
+     *
+     * If checking for the max request size is enabled, we'll want to ensure
+     * that the call payload is less than 32kb.
+     *
+     * If it is larger than 32kb it will not be added to the queue.
+     *
+     * @see https://segment.com/docs/sources/server/http/#max-request-size
+     */
+    if ($this->check_max_request_size) {
+
+        if ($call_size = strlen(json_encode($item)) >= self::MAX_REQUEST_CALL_SIZE_LIMIT ) {
+            $this->handleError(400,"The call exceeds batch import limits ($call_size bytes)");
+            return false;
+        }
     }
 
     $count = array_push($this->queue, $item);
@@ -119,11 +157,62 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
 
     $count = count($this->queue);
     $success = true;
+    $batch_size = $this->batch_size;
 
     while($count > 0 && $success) {
 
-      $batch = array_splice($this->queue, 0, min($this->batch_size, $count));
-      $success = $this->flushBatch($batch);
+        /*
+         * We use array_slice to non destructively get a batch from the queued
+         * array of calls. In the event that the batch is too big, we will try
+         * with a smaller batch size.
+         */
+        $batch = array_slice($this->queue, 0, min($batch_size, $count));
+
+        $body = $this->payload($batch);
+        $payload = json_encode($body);
+
+        /**
+         * There is a maximum of 500kb per batch request and 32kb per call.
+         *
+         * If checking for the max request size is enabled, we'll want to ensure
+         * that the entire payload is less than 500kb.
+         *
+         * If it is over 500kb, we retry at a smaller batch size until it's under
+         * the limit.
+         *
+         * @see https://segment.com/docs/sources/server/http/#max-request-size
+         */
+        if ($this->check_max_request_size) {
+
+            if ($payload_size = strlen($payload) >= self::MAX_REQUEST_BATCH_SIZE_LIMIT ) {
+
+                /*
+                 * If the payload size is too large with only 1 call in it then
+                 * there isn't anything else we can do but report it as an error.
+                 */
+                if ($batch_size == 1) {
+
+                    $this->handleError(400, "The batch size is over the API limit ($payload_size bytes)");
+
+                    return false;
+                }
+
+                /*
+                 * Reduce the batch size and try again
+                 */
+                $batch_size = round($batch_size / 2);
+                continue;
+            }
+        }
+
+      /*
+       * Now that we're sure this is the payload we want to use and that it is
+       * within the max batch request size limit, we'll remove the calls from
+       * the queue using array_splice.
+       */
+      array_splice($this->queue, 0, min($batch_size, $count));
+
+      $success = $success && $this->flushBatch($payload);
 
       $count = count($this->queue);
     }
@@ -134,7 +223,7 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
   /**
    * Given a batch of messages the method returns
    * a valid payload.
-   * 
+   *
    * @param {Array} batch
    * @return {Array}
    **/
@@ -147,8 +236,8 @@ abstract class Segment_QueueConsumer extends Segment_Consumer {
 
   /**
    * Flushes a batch of messages.
-   * @param  [type] $batch [description]
+   * @param  string $payload JSON payload of the batch
    * @return [type]        [description]
    */
-  abstract function flushBatch($batch);
+  abstract function flushBatch($payload);
 }


### PR DESCRIPTION
## What
This PR adds an option to ensure that the payload sizes of requests are within Segment's API guidelines before sending and if it cannot, raise an error when it happens.

## Why
There is a maximum of 500kb per batch and 32kb per call. We can prevent ourselves from sending payloads we know will not be accepted with these changes.

By more intelligently sending batches that we know are under 500kb we can prevent silent data loss at the API level. Also, by checking at an individual call level for the 32kb limit we can ensure we trigger errors when those are too large.

## Breaking changes
I suggest a major release (if we're following SemVer) as there are breaking changes to the `flushBatch` abstract method in the `Segment_QueueConsumer` class.