### PR TITLE
Always set default context.

### DIFF
--- a/lib/Segment/Client.php
+++ b/lib/Segment/Client.php
@@ -179,8 +179,8 @@ class Segment_Client {
 
     if (!isset($msg["context"])) {
       $msg["context"] = array();
-      $msg["context"] = array_merge($msg["context"], $this->getContext());
     }
+    $msg["context"] = array_merge($this->getDefaultContext(), $msg["context"]);
 
     if (!isset($msg["timestamp"])) $msg["timestamp"] = null;
     $msg["timestamp"] = $this->formatTime($msg["timestamp"]);
@@ -212,7 +212,7 @@ class Segment_Client {
    * Add the segment.io context to the request
    * @return array additional context
    */
-  private function getContext () {
+  private function getDefaultContext () {
     global $SEGMENT_VERSION;
     return array(
       "library" => array(

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -36,7 +36,7 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
         "path" => "/docs/libraries/php/",
         "url" => "https://segment.io/docs/libraries/php/"
       )
-    )));    
+    )));
   }
 
   function testPage(){
@@ -140,6 +140,24 @@ class AnalyticsTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(Segment::alias(array(
       "previousId" => "previous-id",
       "userId" => "user-id"
+    )));
+  }
+
+  function testContextEmpty() {
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "Context Test",
+      "context" => array()
+    )));
+  }
+
+  function testContextCustom() {
+    $this->assertTrue(Segment::track(array(
+      "userId" => "user-id",
+      "event" => "Context Test",
+      "context" => array(
+        "active" => false
+      )
     )));
   }
 


### PR DESCRIPTION
Previously if a user sends the `.context` field, we would not send
any default context fields, such as `context.library`.

The new behvaiour is that a user can send `context`, and we will
merge it with the default context before sending.

This change fixes this behaviour so that the user defined `context` is
merged with the default Segment context.

The implementation does allow the user to send a custom
`context.library` (i.e. it doesn't override any fields they send). I did this because that's what the old behaviour was.

Closes https://github.com/segmentio/analytics-php/issues/88.