### PR TITLE
Fix tslint error in version.php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 
 release:
 	@printf "releasing ${VERSION}..."
-	@printf '<?php\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = "%b";\n?>' ${VERSION} > ./lib/Segment/Version.php
+	@printf '<?php\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = "%b";\n' ${VERSION} > ./lib/Segment/Version.php
 	@node -e "var fs = require('fs'), pkg = require('./composer'); pkg.version = '${VERSION}'; fs.writeFileSync('./composer.json', JSON.stringify(pkg, null, '\t'));"
 	@git changelog -t ${VERSION}
 	@git release ${VERSION}

--- a/lib/Segment/Version.php
+++ b/lib/Segment/Version.php
@@ -1,4 +1,3 @@
 <?php
 global $SEGMENT_VERSION;
 $SEGMENT_VERSION = "1.6.0-beta";
-?>


### PR DESCRIPTION
The trailing "?>" occurs error while checking the source code with phplint.
So I removed it from Version.php and it's verified successfully in TravisCI.