### PR TITLE
Escape all input arguments that end up in shell

### DIFF
--- a/lib/Segment/Consumer/ForkCurl.php
+++ b/lib/Segment/Consumer/ForkCurl.php
@@ -33,7 +33,7 @@ class Segment_Consumer_ForkCurl extends Segment_QueueConsumer {
 
     // Escape for shell usage.
     $payload = escapeshellarg($payload);
-    $secret = $this->secret;
+    $secret = escapeshellarg($this->secret);
 
     $protocol = $this->ssl() ? "https://" : "http://";
     if ($this->host) {


### PR DESCRIPTION
This prevents a potentially user-controlled variable from being concatenated directly into a shell command (Jeevan asked me to make a pull request with a fix).