### PR TITLE
Update circleci yaml to include multiple workflows for multiple PHP images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  "image":
+  "build":
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -64,7 +64,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - build
       - test
 
 
@@ -84,7 +84,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - build
       - test
 
   "php-7.1":
@@ -102,7 +102,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - build
       - test
 
   "php-7.3":
@@ -120,7 +120,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - build
       - test
 
   "php-7.4":
@@ -138,7 +138,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - build
       - test
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  "build":
+  build:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -34,7 +34,7 @@ jobs:
           key: node-v1-{{ checksum "composer.json" }}
           paths:
             - node_modules
-  "test":
+  test:
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'
@@ -104,7 +104,7 @@ jobs:
     steps:
       - build
       - test
-
+      
   "php-7.3":
     docker:
       # Specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 commands:
-  setupenv:
+  image:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -65,7 +65,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - setupenv
+      - image
       - test
 
 
@@ -85,7 +85,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - setupenv
+      - image
       - test
 
   "php-7.1":
@@ -103,7 +103,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - setupenv
+      - image
       - test
 
   "php-7.3":
@@ -121,7 +121,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - setupenv
+      - image
       - test
 
   "php-7.4":
@@ -139,7 +139,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - setupenv
+      - image
       - test
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,3 +66,17 @@ jobs:
       #- run: ./vendor/bin/phpunit
       #- run: ./vendor/bin/codecept build
       #- run: ./vendor/bin/codecept run
+      version: 2.1
+orbs:
+  node: circleci/node@1.1
+jobs:
+  build:
+    executor:
+      name: node/default
+      tag: '10.4'
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+      - run: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@
 version: 2
 commands:
   setupenv:
+    steps:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -36,6 +37,7 @@ commands:
             - node_modules
 
   test:     
+    steps:
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  build:
+  "build":
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -34,7 +34,7 @@ jobs:
           key: node-v1-{{ checksum "composer.json" }}
           paths:
             - node_modules
-  test:
+  "test":
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'
@@ -104,7 +104,7 @@ jobs:
     steps:
       - build
       - test
-      
+
   "php-7.3":
     docker:
       # Specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
 version: 2
-jobs:
-  "image":
+commands:
+  image:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -34,7 +34,8 @@ jobs:
           key: node-v1-{{ checksum "composer.json" }}
           paths:
             - node_modules
-  "test":
+
+  test:     
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'
@@ -47,8 +48,8 @@ jobs:
       - run:
           when: on_success
           name: 'Code coverage'
-          command: 'bash <(curl -s https://codecov.io/bash)'
-
+          command: 'bash <(curl -s https://codecov.io/bash)'     
+jobs:
   "php-5":
     docker:
       # Specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  "php-5.3":
+  "php-5":
     docker:
       # Specify the version you desire here
       - image: circleci/php:5.3-node-browsers
@@ -299,12 +299,12 @@ jobs:
           name: 'Code coverage'
           command: 'bash <(curl -s https://codecov.io/bash)'
 
-          
+
 workflows:
   version: 2
   build:
     jobs:
-      - "php-5.3"
+      - "php-5"
       - "php-5.6"
       - "php-7.1"
       - "php-7.3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@
 version: 2
 commands:
   setupenv:
-    steps:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -37,7 +36,6 @@ commands:
             - node_modules
 
   test:     
-    steps:
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,21 +4,7 @@
 #
 version: 2
 jobs:
-  "php-5":
-    docker:
-      # Specify the version you desire here
-      - image: circleci/php:5-node-browsers
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # Using the RAM variation mitigates I/O contention
-      # for database intensive operations.
-      # - image: circleci/mysql:5.7-ram
-      #
-      # - image: redis:2.8.19
-
-    steps:
+  build:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -48,7 +34,7 @@ jobs:
           key: node-v1-{{ checksum "composer.json" }}
           paths:
             - node_modules
-
+  test:
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'
@@ -62,6 +48,26 @@ jobs:
           when: on_success
           name: 'Code coverage'
           command: 'bash <(curl -s https://codecov.io/bash)'
+
+  "php-5":
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:5-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
+      - build
+      - test
+
+
   
   "php-5.6":
     docker:
@@ -78,49 +84,8 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - checkout
-
-      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install zip
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: composer install -n --prefer-dist
-
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
-          paths:
-            - ./vendor
-      - restore_cache:
-          keys:
-            - node-v1-{{ checksum "composer.json" }}
-            - node-v1-
-      - run: yarn install
-      - save_cache:
-          key: node-v1-{{ checksum "composer.json" }}
-          paths:
-            - node_modules
-
-      # run tests with phpunit or codecept
-      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
-      #- run: 'phpunit'
-      - run:
-          name: 'Running unit tests'
-          command: './vendor/bin/phpunit test'
-      - run:
-          name: 'Running E2E tests'
-          command: '.buildscript/e2e.sh'
-      - run:
-          when: on_success
-          name: 'Code coverage'
-          command: 'bash <(curl -s https://codecov.io/bash)'
+      - build
+      - test
 
   "php-7.1":
     docker:
@@ -137,50 +102,9 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - checkout
-
-      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install zip
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: composer install -n --prefer-dist
-
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
-          paths:
-            - ./vendor
-      - restore_cache:
-          keys:
-            - node-v1-{{ checksum "composer.json" }}
-            - node-v1-
-      - run: yarn install
-      - save_cache:
-          key: node-v1-{{ checksum "composer.json" }}
-          paths:
-            - node_modules
-
-      # run tests with phpunit or codecept
-      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
-      #- run: 'phpunit'
-      - run:
-          name: 'Running unit tests'
-          command: './vendor/bin/phpunit test'
-      - run:
-          name: 'Running E2E tests'
-          command: '.buildscript/e2e.sh'
-      - run:
-          when: on_success
-          name: 'Code coverage'
-          command: 'bash <(curl -s https://codecov.io/bash)'
-
+      - build
+      - test
+      
   "php-7.3":
     docker:
       # Specify the version you desire here
@@ -196,49 +120,8 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - checkout
-
-      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install zip
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: composer install -n --prefer-dist
-
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
-          paths:
-            - ./vendor
-      - restore_cache:
-          keys:
-            - node-v1-{{ checksum "composer.json" }}
-            - node-v1-
-      - run: yarn install
-      - save_cache:
-          key: node-v1-{{ checksum "composer.json" }}
-          paths:
-            - node_modules
-
-      # run tests with phpunit or codecept
-      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
-      #- run: 'phpunit'
-      - run:
-          name: 'Running unit tests'
-          command: './vendor/bin/phpunit test'
-      - run:
-          name: 'Running E2E tests'
-          command: '.buildscript/e2e.sh'
-      - run:
-          when: on_success
-          name: 'Code coverage'
-          command: 'bash <(curl -s https://codecov.io/bash)'
+      - build
+      - test
 
   "php-7.4":
     docker:
@@ -255,49 +138,8 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - checkout
-
-      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install zip
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: composer install -n --prefer-dist
-
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
-          paths:
-            - ./vendor
-      - restore_cache:
-          keys:
-            - node-v1-{{ checksum "composer.json" }}
-            - node-v1-
-      - run: yarn install
-      - save_cache:
-          key: node-v1-{{ checksum "composer.json" }}
-          paths:
-            - node_modules
-
-      # run tests with phpunit or codecept
-      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
-      #- run: 'phpunit'
-      - run:
-          name: 'Running unit tests'
-          command: './vendor/bin/phpunit test'
-      - run:
-          name: 'Running E2E tests'
-          command: '.buildscript/e2e.sh'
-      - run:
-          when: on_success
-          name: 'Code coverage'
-          command: 'bash <(curl -s https://codecov.io/bash)'
+      - build
+      - test
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  "build":
+  "image":
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -64,7 +64,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
+      - image
       - test
 
 
@@ -84,7 +84,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
+      - image
       - test
 
   "php-7.1":
@@ -102,7 +102,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
+      - image
       - test
 
   "php-7.3":
@@ -120,7 +120,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
+      - image
       - test
 
   "php-7.4":
@@ -138,7 +138,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
+      - image
       - test
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,125 @@
 #
 version: 2
 jobs:
-  build:
+  "php-5.3":
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:5.3-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
+  
+  "php-5.6":
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:5.6-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
+
+  "php-7.1":
     docker:
       # Specify the version you desire here
       - image: circleci/php:7.1-node-browsers
@@ -63,6 +181,133 @@ jobs:
           name: 'Code coverage'
           command: 'bash <(curl -s https://codecov.io/bash)'
 
-      #- run: ./vendor/bin/phpunit
-      #- run: ./vendor/bin/codecept build
-      #- run: ./vendor/bin/codecept run
+  "php-7.3":
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:7.3-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
+
+  "php-7.4":
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:7.4-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
+
+          
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "php-5.3"
+      - "php-5.6"
+      - "php-7.1"
+      - "php-7.3"
+      - "php-7.4"
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,17 +66,3 @@ jobs:
       #- run: ./vendor/bin/phpunit
       #- run: ./vendor/bin/codecept build
       #- run: ./vendor/bin/codecept run
-      version: 2.1
-orbs:
-  node: circleci/node@1.1
-jobs:
-  build:
-    executor:
-      name: node/default
-      tag: '10.4'
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install
-      - run: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 commands:
-  image:
+  setupenv:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -65,7 +65,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - setupenv
       - test
 
 
@@ -85,7 +85,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - setupenv
       - test
 
   "php-7.1":
@@ -103,7 +103,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - setupenv
       - test
 
   "php-7.3":
@@ -121,7 +121,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - setupenv
       - test
 
   "php-7.4":
@@ -139,7 +139,7 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - image
+      - setupenv
       - test
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
 version: 2
-commands:
-  image:
+jobs:
+  "image":
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -34,8 +34,7 @@ commands:
           key: node-v1-{{ checksum "composer.json" }}
           paths:
             - node_modules
-
-  test:     
+  "test":
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'
@@ -48,8 +47,8 @@ commands:
       - run:
           when: on_success
           name: 'Code coverage'
-          command: 'bash <(curl -s https://codecov.io/bash)'     
-jobs:
+          command: 'bash <(curl -s https://codecov.io/bash)'
+
   "php-5":
     docker:
       # Specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,21 @@
 #
 version: 2
 jobs:
-  build:
+  "php-5":
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:5-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
@@ -34,7 +48,7 @@ jobs:
           key: node-v1-{{ checksum "composer.json" }}
           paths:
             - node_modules
-  test:
+
       # run tests with phpunit or codecept
       #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
       #- run: 'phpunit'
@@ -48,26 +62,6 @@ jobs:
           when: on_success
           name: 'Code coverage'
           command: 'bash <(curl -s https://codecov.io/bash)'
-
-  "php-5":
-    docker:
-      # Specify the version you desire here
-      - image: circleci/php:5-node-browsers
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # Using the RAM variation mitigates I/O contention
-      # for database intensive operations.
-      # - image: circleci/mysql:5.7-ram
-      #
-      # - image: redis:2.8.19
-
-    steps:
-      - build
-      - test
-
-
   
   "php-5.6":
     docker:
@@ -84,8 +78,49 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
-      - test
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
 
   "php-7.1":
     docker:
@@ -102,9 +137,50 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
-      - test
-      
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
+
   "php-7.3":
     docker:
       # Specify the version you desire here
@@ -120,8 +196,49 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
-      - test
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
 
   "php-7.4":
     docker:
@@ -138,8 +255,49 @@ jobs:
       # - image: redis:2.8.19
 
     steps:
-      - build
-      - test
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "composer.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "composer.json" }}
+          paths:
+            - node_modules
+
+      # run tests with phpunit or codecept
+      #- run: 'if [[ ! ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then  composer require overtrue/phplint; composer require squizlabs/php_codesniffer; ./vendor/bin/phplint; ./vendor/bin/phpcs; fi'
+      #- run: 'phpunit'
+      - run:
+          name: 'Running unit tests'
+          command: './vendor/bin/phpunit test'
+      - run:
+          name: 'Running E2E tests'
+          command: '.buildscript/e2e.sh'
+      - run:
+          when: on_success
+          name: 'Code coverage'
+          command: 'bash <(curl -s https://codecov.io/bash)'
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   "php-5":
     docker:
       # Specify the version you desire here
-      - image: circleci/php:5.3-node-browsers
+      - image: circleci/php:5-node-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
#132 
Update circleci config to test on multiple PHP platforms, pre-built docker images do not conform to our versions so current tests are 5.0, 5.6, 7.1, 7.3 and 7.4.  We really only need to test to 7.3 at the moment, but since 7.4 is available I added it to the list.