### PR TITLE
Fallback to global project's autoloader

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -3,7 +3,7 @@
 
 use Segment\Segment;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../bootstrap.php';
 
 if (in_array('--help', $argv, true)) {
     print(usage());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+foreach (
+    [
+        __DIR__ . '/vendor/autoload.php',
+        __DIR__ . '/../../autoload.php',
+    ] as $autoload
+) {
+    if (is_file($autoload)) {
+        return require_once $autoload;
+    }
+}
+
+fwrite(
+    STDERR,
+    'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
+    '    composer install' . PHP_EOL . PHP_EOL .
+    'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
+);
+
+exit(1);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          backupGlobals="true"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/send.php
+++ b/send.php
@@ -8,7 +8,7 @@ use Segment\Segment;
  * require client
  */
 
-require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/bootstrap.php';
 
 /**
  * Args


### PR DESCRIPTION
This change is meant to make the installation easier.

As of today, if I add this library to my project with Composer (`composer require segmentio/analytics-php`), I cannot run `vendor/bin/analytics` right away, but I need to also generate another autoloader (`composer -d vendor/segmentio/analytics-php/ dump-autoload`).

After this change, this extra step won't be no longer be required.