### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "segmentio/analytics-php",
-	"version": "3.6.0",
 	"description": "Segment Analytics PHP Library",
 	"keywords": [
 		"analytics",


### PR DESCRIPTION
Remove **highly discouraged** `version` from Composer configuration.

Please see the quartz-colored note.
https://getcomposer.org/doc/04-schema.md#version
