### PR TITLE
fix: allow passing milliseconds in event timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint: dependencies
 
 release:
 	@printf "releasing ${VERSION}..."
-	@printf '<?php\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = "%b";\n' ${VERSION} > ./lib/Version.php
+	@printf "<?php\n\ndeclare(strict_types=1);\n\nglobal $$SEGMENT_VERSION;\n$$SEGMENT_VERSION = '%b';\n" ${VERSION} > ./lib/Version.php
 	@git changelog -t ${VERSION}
 	@git release ${VERSION}
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -93,7 +93,7 @@ class Client
         if (!isset($msg['timestamp'])) {
             $msg['timestamp'] = null;
         }
-        $msg['timestamp'] = $this->formatTime((int)$msg['timestamp']);
+        $msg['timestamp'] = $this->formatTime($msg['timestamp']);
 
         if (!isset($msg['messageId'])) {
             $msg['messageId'] = self::messageId();

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 global $SEGMENT_VERSION;
 
 $SEGMENT_VERSION = '3.8.0';


### PR DESCRIPTION
The presence of the cast to integer makes it impossible to specify a timestamp with milli / micro seconds.

#234 