### PR TITLE
Fix curl_close() deprecation in PHP 8.5

### DIFF
--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -74,8 +74,11 @@ class LibCurl extends QueueConsumer
 
             $responseCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-            //close connection
-            curl_close($ch);
+            // This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.
+            // @link https://www.php.net/manual/en/function.curl-close.php
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
             if ($responseCode !== 200) {
                 // log error


### PR DESCRIPTION
## Summary
- `curl_close()` has no effect since PHP 8.0 (handles are now `CurlHandle` objects auto-closed by GC) and is formally deprecated in PHP 8.5
- Only call `curl_close()` on PHP < 8.0 where handles are still resources
-  https://www.php.net/manual/en/function.curl-close.php

## Test plan
- [x] Verify no deprecation warnings on PHP 8.5
- [x] Verify backward compatibility on PHP 7.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)